### PR TITLE
Changed default port to 9291

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Set up your exporter. Edit your credentials YAML file. A `sample credentials YAM
 
   $ zhmc_prometheus_exporter -c samplecreds.yaml -m metrics.yaml
 
-where ``metrics.yaml`` defines the metrics and descriptions. You do not have to edit ``metrics.yaml``. The default port is 8000, you can change it with ``-p``.
+where ``metrics.yaml`` defines the metrics and descriptions. You do not have to edit ``metrics.yaml``. The default port is 9291, you can change it with ``-p``.
 
 .. _sample credentials YAML: examples/samplecreds.yaml
 
@@ -49,7 +49,7 @@ Demo setup
 
 If you want a quick "three simple metrics" setup with Prometheus and Grafana you can proceed as follows:
 
-* Set up a Prometheus server. Get it from `Prometheus`_. A `sample configuration YAML`_ is provided. Fill in the IP and port the exporter will run on. If you left it at default, the port will be 8000. You can then run::
+* Set up a Prometheus server. Get it from `Prometheus`_. A `sample configuration YAML`_ is provided. Fill in the IP and port the exporter will run on. If you left it at default, the port will be 9291. You can then run::
 
     $ ./prometheus --config.file=prometheus.yaml
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -98,14 +98,14 @@ You can then run
 
   $ zhmc_prometheus_exporter -c samplecreds.yaml -m metrics.yaml
 
-, the default port being 8000, you can change it with ``-p``.
+, the default port being 9291, you can change it with ``-p``.
 
 Demo setup
 ^^^^^^^^^^
 
 **Beware that using Prometheus and a possible graphical frontend, Grafana, is not the scope of this project. This is a very sparse guide. Consult their documentations if you want anything more complicated than a "three simple metrics" setup.**
 
-* The Prometheus server scrapes the metrics from the exporter. Get it from `the Prometheus download page`_. A sample configuration YAML is provided in the examples folder. Fill in the IP and port the exporter will run on. If you left it at default, the port will be 8000. From the downloaded directory, you can then run::
+* The Prometheus server scrapes the metrics from the exporter. Get it from `the Prometheus download page`_. A sample configuration YAML is provided in the examples folder. Fill in the IP and port the exporter will run on. If you left it at default, the port will be 9291. From the downloaded directory, you can then run::
 
     $ ./prometheus --config.file=prometheus.yaml
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -37,7 +37,7 @@ You can then run
 
   $ zhmc_prometheus_exporter -c samplecreds.yaml -m metrics.yaml
 
-, the default port being 8000, you can change it with ``-p``.
+, the default port being 9291, you can change it with ``-p``.
 
 Output anatomy
 --------------

--- a/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
+++ b/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
@@ -64,8 +64,8 @@ def parse_args(args):
     """Parses the CLI arguments."""
     parser = argparse.ArgumentParser(description="Prometheus.io exporter for "
                                      "the IBM Z Hardware Management Console")
-    parser.add_argument("-p", metavar="PORT", default="8000", help="Port for "
-                        "exporting (default 8000)")
+    parser.add_argument("-p", metavar="PORT", default="9291", help="Port for "
+                        "exporting (default 9291)")
     parser.add_argument("-c", metavar="CREDENTIALS", help="Credentials "
                         "information (YAML)", required=True)
     parser.add_argument("-m", metavar="METRICS", help="Metrics information "


### PR DESCRIPTION
The default port for the exporter was 8000. It is now 9291, the smallest free port on the list of allocated ports. This change is also reflected in the documentation.