### PR TITLE
Unified docs style with other zhmcclient projects

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,7 +75,7 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'alabaster'
+html_theme = 'classic'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,20 @@
+.. Copyright 2018 IBM Corp. All Rights Reserved.
+..
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. you may not use this file except in compliance with the License.
+.. You may obtain a copy of the License at
+..
+..    http://www.apache.org/licenses/LICENSE-2.0
+..
+.. Unless required by applicable law or agreed to in writing, software
+.. distributed under the License is distributed on an "AS IS" BASIS,
+.. WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+.. See the License for the specific language governing permissions and
+.. limitations under the License.
+
+zhmc-prometheus-exporter - A prometheus.io exporter for the IBM Z Hardware Management Console
+=============================================================================================
+
 .. toctree::
    :maxdepth: 2
    :numbered:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -96,6 +96,7 @@ The metrics YAML file
 Various properties about scraping are collected from the ``metrics.yaml`` file that is given to the exporter with the ``-m`` option.
 
 The metric groups section
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 contains the metric groups, as seen on the first level of the lists in :ref:`Available metrics`.
 
@@ -110,6 +111,7 @@ Example:
 Within one section, the metric prefix and the fetch True/False value is stored. The latter is due to runtime concerns: Some metric groups take over a second to be scraped.
 
 The metrics section
+^^^^^^^^^^^^^^^^^^^
 
 contains the metrics themselves, as seen on the second level of the lists in :ref:`Available metrics`.
 


### PR DESCRIPTION
The most noticeable change is the switch to the "Classic" Sphinx theme (was: "Alabaster"). The Index documentation page was also edited with respect to the standards from other zhmcclient projects.