### PR TITLE
Increased textwidth of documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,7 +81,7 @@ html_theme = 'classic'
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {"body_max_width": "100%"}
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,


### PR DESCRIPTION
To further converge to the documentation of other zhmcclient projects, the textwidth is no longer limited.