### PR TITLE
Avoid exception in exception handling

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -22,6 +22,20 @@
 Change log
 ----------
 
+Version 0.4.0
+^^^^^^^^^^^^^
+
+Released: xxxx-xx-xx
+
+**Bug fixes:**
+- Avoid exception in case of a connection drop error handling.
+
+**Known issues:** See the `list of open issues`_.
+
+.. _list of open issues: https://github.com/zhmcclient/zhmc-prometheus-exporter/issue
+
+
+
 Version 0.3.0
 ^^^^^^^^^^^^^
 

--- a/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
+++ b/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
@@ -353,7 +353,9 @@ class ZHMCUsageCollector():
             retrieved_metrics = retrieve_metrics(self.context)
         except zhmcclient.HTTPError as exc:
             if exc.http_status == 404 and exc.reason == 1:
-                delete_metrics_context(self.session, self.context)
+                # Disable this line because it leads sometimes to
+                # an exception within the exception handling.
+                # delete_metrics_context(self.session, self.context)
                 self.session = create_session(self.yaml_creds)
                 self.context = create_metrics_context(self.session,
                                                       self.yaml_metric_groups,


### PR DESCRIPTION
Disable calling delete_metrics_context
because it leads sometimes to an exception
within the exception handling.

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>