### PR TITLE
Use safe_load() instead of insecure load()

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -29,6 +29,9 @@ Released: xxxx-xx-xx
 
 **Bug fixes:**
 - Avoid exception in case of a connection drop error handling.
+- Replace yaml.load() by yaml.safe_load(). In PyYAML before 5.1,
+  the yaml.load() API could execute arbitrary code if used with untrusted data
+  (CVE-2017-18342).
 
 **Known issues:** See the `list of open issues`_.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-PyYAML>=3.13 # MIT
+PyYAML>=5.1 # MIT
 zhmcclient>=0.19.0 # Apache-2.0
 prometheus-client>=0.3.1 # Apache-2.0

--- a/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
+++ b/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
@@ -83,7 +83,7 @@ def parse_yaml_file(yamlfile):
     """
     try:
         with open(yamlfile, "r") as yamlcontent:
-            return yaml.load(yamlcontent)
+            return yaml.safe_load(yamlcontent)
     except PermissionError:
         raise PermissionError("Permission error. Make sure you have "
                               "appropriate permissions to read from %s."


### PR DESCRIPTION
Replace yaml.load() by yaml.safe_load(). In PyYAML before 5.1,
the yaml.load() API could execute arbitrary code
if used with untrusted data (CVE-2017-18342).

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>