### PR TITLE
Replace SHA1 by SHA256 hash function

### DIFF
--- a/zhmc_prometheus_exporter/test.py
+++ b/zhmc_prometheus_exporter/test.py
@@ -58,8 +58,8 @@ class TestParseYaml(unittest.TestCase):
 
     def test_normal_input(self):
         """Tests if some generic file is correctly parsed."""
-        # Get a SHA1 of Unixtime to create a filename that does not exist
-        filename = str(hashlib.sha1(str(time.time()).encode("utf-8")).
+        # Get a SHA256 of Unixtime to create a filename that does not exist
+        filename = str(hashlib.sha256(str(time.time()).encode("utf-8")).
                        hexdigest())
         with open(filename, "w+") as testfile:
             testfile.write("""metrics:
@@ -76,7 +76,7 @@ class TestParseYaml(unittest.TestCase):
 
     def test_permission_error(self):
         """Tests if permission denied is correctly handled."""
-        filename = str(hashlib.sha1(str(time.time()).encode("utf-8")).
+        filename = str(hashlib.sha256(str(time.time()).encode("utf-8")).
                        hexdigest())
         with open(filename, "w+"):
             pass
@@ -89,7 +89,7 @@ class TestParseYaml(unittest.TestCase):
 
     def test_not_found_error(self):
         """Tests if file not found is correctly handled."""
-        filename = str(hashlib.sha1(str(time.time()).encode("utf-8")).
+        filename = str(hashlib.sha256(str(time.time()).encode("utf-8")).
                        hexdigest())
         with self.assertRaises(FileNotFoundError):
             zhmc_prometheus_exporter.parse_yaml_file(filename)


### PR DESCRIPTION
Because of a sonarcube finding we replace
the SAH1 hash function by a SHA256 function.
See description of the rule B303
at the Bandit website:
https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b303-md

Signed-off-by: Juergen Leopold <leopoldj@de.ibm.com>