### PR TITLE
Exclued Python 3.4 on macOS from tests ( no longer exists)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,13 @@ jobs:
             \"os\": [ \"ubuntu-latest\", \"macos-latest\", \"windows-latest\" ], \
             \"python-version\": [ \"3.4\", \"3.5\", \"3.6\", \"3.7\", \"3.8\", \"3.9\" ], \
             \"package_level\": [ \"latest\" ] \
+            \"exclude\": [ \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.4\", \
+                \"package_level\": \"latest\" \
+              }, \
+            ] \
           }"; \
         else \
           echo "::set-output name=matrix::{ \


### PR DESCRIPTION
No review needed.