### PR TITLE
Added processor type as label on 'zcpc-processor-usage' metrics group

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,9 @@ Released: not yet
 * Added support for logging the HMC interactions with new options `--log-dest`
   and `--log-comp`. (issue #121)
 
+* Added the processor type as a label on the metrics of the 'zcpc-processor-usage'
+  metrics group. (issue #102)
+
 **Cleanup:**
 
 **Known issues:**

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -188,7 +188,7 @@ network-physical-adapter-port         D     zhmc_port_*                  cpc, ad
 partition-attached-network-interface  D     zhmc_nic_*                   cpc, partition, nic
 zcpc-environmentals-and-power         C+D   zhmc_cpc_*                   cpc
 environmental-power-status            C+D   zhmc_cpc_*                   cpc
-zcpc-processor-usage                  C+D   zhmc_processor_*             cpc, processor
+zcpc-processor-usage                  C+D   zhmc_processor_*             cpc, processor, type
 ====================================  ====  ===========================  ======================
 
 Legend:

--- a/examples/metrics.yaml
+++ b/examples/metrics.yaml
@@ -132,6 +132,8 @@ metric_groups:
         value: resource
       - name: processor
         value: processor-name
+      - name: type
+        value: processor-type
 
   environmental-power-status:
     prefix: cpc
@@ -766,7 +768,7 @@ metrics:
     processor-type:
       # type: info
       percent: false
-      exporter_name: null  # Ignored (redundant with processor-name)
+      exporter_name: null  # Ignored (used as label, also included in processor-name)
       exporter_desc: null
     processor-usage:
       percent: true
@@ -775,7 +777,7 @@ metrics:
     smt-usage:
       percent: false
       exporter_name: smt_mode_percent
-      exporter_desc: Percentage of time the processor was in in SMT mode - -1 if not supported
+      exporter_desc: Percentage of time the processor was in SMT mode - -1 if not supported
     thread-0-usage:
       percent: true
       exporter_name: smt_thread0_usage_ratio


### PR DESCRIPTION
See commit message.