### PR TITLE
Increased minimum version of zhmcclient to 0.29.0

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,6 +39,8 @@ Released: not yet
 * Added the processor type as a label on the metrics of the 'zcpc-processor-usage'
   metrics group. (issue #102)
 
+* Increased minimum version of zhmcclient to 0.29.0.
+
 **Cleanup:**
 
 **Known issues:**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
-# TODO: Enable zhmcclient 0.29.0 again once released.
-git+https://github.com/zhmcclient/python-zhmcclient@master#egg=zhmcclient
-# zhmcclient>=0.29.0 # Apache-2.0
+zhmcclient>=0.29.0 # Apache-2.0
 
 prometheus-client>=0.3.1 # Apache-2.0
 urllib3>=1.24.0


### PR DESCRIPTION
No review needed.