### PR TITLE
Restrict zhmcclient version no more than 0.30.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-zhmcclient>=0.19.0 # Apache-2.0
+zhmcclient>=0.19.0,<=0.30.2 # Apache-2.0
 prometheus-client>=0.3.1 # Apache-2.0
 urllib3>=1.24.0
 jsonschema>=2.6.0


### PR DESCRIPTION
Restrict zhmcclient version no more than 0.30.2 to avoid schema validation error

Signed-off-by: Mu Chen <chenmu@cn.ibm.com>