### PR TITLE
Release 0.6.1

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,14 +17,10 @@ Change log
 ----------
 
 
-Version 0.6.1.dev1
-^^^^^^^^^^^^^^^^^^
+Version 0.6.1
+^^^^^^^^^^^^^
 
-Released: not yet
-
-**Incompatible changes:**
-
-**Deprecations:**
+Released: 2021-06-14
 
 **Bug fixes:**
 
@@ -34,16 +30,6 @@ Released: not yet
 * Pinned zhmcclient to <0.31.0 to avoid its incompatible verify_cert parameter.
   The future version 0.7.0 will support the verify_cert parameter of zhmcclient.
   (issue #145)
-
-**Enhancements:**
-
-**Cleanup:**
-
-**Known issues:**
-
-* See `list of open issues`_.
-
-.. _`list of open issues`: https://github.com/zhmcclient/zhmc-prometheus-exporter/issues
 
 
 Version 0.6.0

--- a/zhmc_prometheus_exporter/_version.py
+++ b/zhmc_prometheus_exporter/_version.py
@@ -25,4 +25,4 @@ __all__ = ['__version__']
 #:
 #: * "M.N.P.dev1": A not yet released version M.N.P
 #: * "M.N.P": A released version M.N.P
-__version__ = '0.6.1.dev1'
+__version__ = '0.6.1'


### PR DESCRIPTION
Provides a fix that prevents using the exporter with HMCs with self-signed certificates, since zhmcclient 0.31.0 was releaed.