### PR TITLE
Added support for metrics based on resource properties of CPCs and partitions

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,9 @@ Released: not yet
 
 **Enhancements:**
 
+* Added support for metrics based on resource properties of CPCs, partitions
+  (DPM mode) and LPARs (classic mode). (issue #112)
+
 **Cleanup:**
 
 **Known issues:**

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -225,40 +225,64 @@ usage percentages of two partitions in a single CPC:
 Available metrics
 -----------------
 
-The exporter code is agnostic to the actual set of metrics supported by the
-HMC. A new metric can immediately be supported by just adding it to the
-:ref:`metric definition file`.
+The exporter supports two types of metrics. These metrics are differently
+retrieved from the HMC, but they are exported to Prometheus in the same way:
+
+* HMC metric service based - These metrics are retrieved from the HMC using the
+  "Get Metric Context" operation each time Prometheus retrieves metrics from the
+  exporter.
+
+* HMC resource property based - These metrics are actually the values of
+  properties of HMC resources, such as the number of processors assigned
+  to a partition. The exporter maintains representations of the corresponding
+  resources in memory. These representations are automatically and
+  asynchronously updated via HMC object notifications. When Prometheus retrieves
+  these metrics from the exporter, the exporter always has up-to-date resource
+  representations and can immediately return them without having to turn around
+  for getting them from the HMC.
+
+The exporter code is agnostic to the actual set of metrics supported by the HMC.
+A new metric exposed by the HMC metric service or a new property added to one of
+the auto-updated resources can immediately be supported by just adding it to
+the :ref:`metric definition file`.
 
 The :ref:`sample metric definition file` in the Git repository states in its
 header up to which HMC version or Z machine generation the metrics are defined.
 
-The following table shows the mapping between HMC metric groups and exported
-Prometheus metrics in the standard metric definition. Note that ensemble and
-zBX related metrics are not covered in the standard metric definition (support
-for them has been removed in z15). For more details on the HMC metrics, see
-section "Metric Groups" in the :term:`HMC API` book.
+The following table shows the mapping between exporter metric groups and
+exported Prometheus metrics in the standard metric definition. Note that
+ensemble and zBX related metrics are not covered in the standard metric
+definition (support for them has been removed in z15). For more details on the
+HMC metrics, see section "Metric Groups" in the :term:`HMC API` book.
+For more details on the resource properties of CPC and Partition (DPM mode)
+and Logical Partition (classic mode), see the corresponding data models
+in the :term:`HMC API` book.
 
-====================================  ====  ===========================  ======================
-HMC Metric Group                      Mode  Prometheus Metrics           Prometheus Labels
-====================================  ====  ===========================  ======================
-cpc-usage-overview                    C     zhmc_cpc_*                   cpc
-logical-partition-usage               C     zhmc_partition_*             cpc, partition
-channel-usage                         C     zhmc_channel_*               cpc, channel_css_chpid
-crypto-usage                          C     zhmc_crypto_adapter_*        cpc, adapter_pchid
-flash-memory-usage                    C     zhmc_flash_memory_adapter_*  cpc, adapter_pchid
-roce-usage                            C     zhmc_roce_adapter_*          cpc, adapter_pchid
-dpm-system-usage-overview             D     zhmc_cpc_*                   cpc
-partition-usage                       D     zhmc_partition_*             cpc, partition
-adapter-usage                         D     zhmc_adapter_*               cpc, adapter
-network-physical-adapter-port         D     zhmc_port_*                  cpc, adapter, port
-partition-attached-network-interface  D     zhmc_nic_*                   cpc, partition, nic
-zcpc-environmentals-and-power         C+D   zhmc_cpc_*                   cpc
-environmental-power-status            C+D   zhmc_cpc_*                   cpc
-zcpc-processor-usage                  C+D   zhmc_processor_*             cpc, processor, type
-====================================  ====  ===========================  ======================
+====================================  ====  ====  ===========================  ======================
+Exporter Metric Group                 Type  Mode  Prometheus Metrics           Prometheus Labels
+====================================  ====  ====  ===========================  ======================
+cpc-usage-overview                    M     C     zhmc_cpc_*                   cpc
+logical-partition-usage               M     C     zhmc_partition_*             cpc, partition
+channel-usage                         M     C     zhmc_channel_*               cpc, channel_css_chpid
+crypto-usage                          M     C     zhmc_crypto_adapter_*        cpc, adapter_pchid
+flash-memory-usage                    M     C     zhmc_flash_memory_adapter_*  cpc, adapter_pchid
+roce-usage                            M     C     zhmc_roce_adapter_*          cpc, adapter_pchid
+dpm-system-usage-overview             M     D     zhmc_cpc_*                   cpc
+partition-usage                       M     D     zhmc_partition_*             cpc, partition
+adapter-usage                         M     D     zhmc_adapter_*               cpc, adapter
+network-physical-adapter-port         M     D     zhmc_port_*                  cpc, adapter, port
+partition-attached-network-interface  M     D     zhmc_nic_*                   cpc, partition, nic
+zcpc-environmentals-and-power         M     C+D   zhmc_cpc_*                   cpc
+environmental-power-status            M     C+D   zhmc_cpc_*                   cpc
+zcpc-processor-usage                  M     C+D   zhmc_processor_*             cpc, processor, type
+cpc-resource                          R     C+D   zhmc_cpc_*                   cpc
+partition-resource                    R     D     zhmc_partition_*             cpc, partition
+logical-partition-resource            R     C     zhmc_partition_*             cpc, partition
+====================================  ====  ====  ===========================  ======================
 
 Legend:
 
+* Type:: The type of the metric group: M=metric service, R=resource property
 * Mode: The operational mode of the CPC: C=Classic, D=DPM
 
 As you can see, the ``zhmc_cpc_*`` and ``zhmc_partition_*`` metrics are used
@@ -266,122 +290,219 @@ for both DPM mode and classic mode. The names of the metrics are equal if and
 only if they have the same meaning in both modes.
 
 The following table shows the Prometheus metrics in the standard metric
-definition:
+definition. This includes both metric service and resource property based metrics:
 
-===============================================  ====  ==================================================================
-Prometheus Metric                                Mode  Description
-===============================================  ====  ==================================================================
-zhmc_cpc_processor_usage_ratio                   C+D   Usage ratio across all processors of the CPC
-zhmc_cpc_shared_processor_usage_ratio            C+D   Usage ratio across all shared processors of the CPC
-zhmc_cpc_dedicated_processor_usage_ratio         C     Usage ratio across all dedicated processors of the CPC
-zhmc_cpc_cp_processor_usage_ratio                C+D   Usage ratio across all CP processors of the CPC
-zhmc_cpc_cp_shared_processor_usage_ratio         C+D   Usage ratio across all shared CP processors of the CPC
-zhmc_cpc_cp_dedicated_processor_usage_ratio      C     Usage ratio across all dedicated CP processors of the CPC
-zhmc_cpc_ifl_processor_usage_ratio               C+D   Usage ratio across all IFL processors of the CPC
-zhmc_cpc_ifl_shared_processor_usage_ratio        C+D   Usage ratio across all shared IFL processors of the CPC
-zhmc_cpc_ifl_dedicated_processor_usage_ratio     C     Usage ratio across all dedicated IFL processors of the CPC
-zhmc_cpc_aap_shared_processor_usage_ratio        C     Usage ratio across all shared zAAP processors of the CPC
-zhmc_cpc_aap_dedicated_processor_usage_ratio     C     Usage ratio across all dedicated zAAP processors of the CPC
-zhmc_cpc_cbp_processor_usage_ratio               C     Usage ratio across all CBP processors of the CPC
-zhmc_cpc_cbp_shared_processor_usage_ratio        C     Usage ratio across all shared CBP processors of the CPC
-zhmc_cpc_cbp_dedicated_processor_usage_ratio     C     Usage ratio across all dedicated CBP processors of the CPC
-zhmc_cpc_icf_processor_usage_ratio               C     Usage ratio across all ICF processors of the CPC
-zhmc_cpc_icf_shared_processor_usage_ratio        C     Usage ratio across all shared ICF processors of the CPC
-zhmc_cpc_icf_dedicated_processor_usage_ratio     C     Usage ratio across all dedicated ICF processors of the CPC
-zhmc_cpc_iip_processor_usage_ratio               C     Usage ratio across all zIIP processors of the CPC
-zhmc_cpc_iip_shared_processor_usage_ratio        C     Usage ratio across all shared zIIP processors of the CPC
-zhmc_cpc_iip_dedicated_processor_usage_ratio     C     Usage ratio across all dedicated zIIP processors of the CPC
-zhmc_cpc_channel_usage_ratio                     C     Usage ratio across all channels of the CPC
-zhmc_cpc_accelerator_adapter_usage_ratio         D     Usage ratio across all accelerator adapters of the CPC
-zhmc_cpc_crypto_adapter_usage_ratio              D     Usage ratio across all crypto adapters of the CPC
-zhmc_cpc_network_adapter_usage_ratio             D     Usage ratio across all network adapters of the CPC
-zhmc_cpc_storage_adapter_usage_ratio             D     Usage ratio across all storage adapters of the CPC
-zhmc_cpc_power_watts                             C+D   Power consumption of the CPC
-zhmc_cpc_ambient_temperature_celsius             C+D   Ambient temperature of the CPC
-zhmc_crypto_adapter_usage_ratio                  C     Usage ratio of the crypto adapter
-zhmc_flash_memory_adapter_usage_ratio            C     Usage ratio of the flash memory adapter
-zhmc_adapter_usage_ratio                         D     Usage ratio of the adapter
-zhmc_channel_usage_ratio                         C     Usage ratio of the channel
-zhmc_roce_adapter_usage_ratio                    C     Usage ratio of the RoCE adapter
-zhmc_partition_processor_usage_ratio             C+D   Usage ratio across all processors of the partition
-zhmc_partition_cp_processor_usage_ratio          C     Usage ratio across all CP processors of the partition
-zhmc_partition_ifl_processor_usage_ratio         C     Usage ratio across all IFL processors of the partition
-zhmc_partition_icf_processor_usage_ratio         C     Usage ratio across all ICF processors of the partition
-zhmc_partition_cbp_processor_usage_ratio         C     Usage ratio across all CBP processors of the partition
-zhmc_partition_iip_processor_usage_ratio         C     Usage ratio across all IIP processors of the partition
-zhmc_partition_accelerator_adapter_usage_ratio   D     Usage ratio of all accelerator adapters of the partition
-zhmc_partition_crypto_adapter_usage_ratio        D     Usage ratio of all crypto adapters of the partition
-zhmc_partition_network_adapter_usage_ratio       D     Usage ratio of all network adapters of the partition
-zhmc_partition_storage_adapter_usage_ratio       D     Usage ratio of all storage adapters of the partition
-zhmc_partition_zvm_paging_rate_pages_per_second  C     z/VM paging rate in pages/sec
-zhmc_port_bytes_sent_count                       D     Number of Bytes in unicast packets that were sent
-zhmc_port_bytes_received_count                   D     Number of Bytes in unicast packets that were received
-zhmc_port_packets_sent_count                     D     Number of unicast packets that were sent
-zhmc_port_packets_received_count                 D     Number of unicast packets that were received
-zhmc_port_packets_sent_dropped_count             D     Number of sent packets that were dropped (resource shortage)
-zhmc_port_packets_received_dropped_count         D     Number of received packets that were dropped (resource shortage)
-zhmc_port_packets_sent_discarded_count           D     Number of sent packets that were discarded (malformed)
-zhmc_port_packets_received_discarded_count       D     Number of received packets that were discarded (malformed)
-zhmc_port_multicast_packets_sent_count           D     Number of multicast packets sent
-zhmc_port_multicast_packets_received_count       D     Number of multicast packets received
-zhmc_port_broadcast_packets_sent_count           D     Number of broadcast packets sent
-zhmc_port_broadcast_packets_received_count       D     Number of broadcast packets received
-zhmc_port_data_sent_bytes                        D     Amount of data sent over the collection interval
-zhmc_port_data_received_bytes                    D     Amount of data received over the collection interval
-zhmc_port_data_rate_sent_bytes_per_second        D     Data rate sent over the collection interval
-zhmc_port_data_rate_received_bytes_per_second    D     Data rate received over the collection interval
-zhmc_port_bandwidth_usage_ratio                  D     Bandwidth usage ratio of the port
-zhmc_nic_bytes_sent_count                        D     Number of Bytes in unicast packets that were sent
-zhmc_nic_bytes_received_count                    D     Number of Bytes in unicast packets that were received
-zhmc_nic_packets_sent_count                      D     Number of unicast packets that were sent
-zhmc_nic_packets_received_count                  D     Number of unicast packets that were received
-zhmc_nic_packets_sent_dropped_count              D     Number of sent packets that were dropped (resource shortage)
-zhmc_nic_packets_received_dropped_count          D     Number of received packets that were dropped (resource shortage)
-zhmc_nic_packets_sent_discarded_count            D     Number of sent packets that were discarded (malformed)
-zhmc_nic_packets_received_discarded_count        D     Number of received packets that were discarded (malformed)
-zhmc_nic_multicast_packets_sent_count            D     Number of multicast packets sent
-zhmc_nic_multicast_packets_received_count        D     Number of multicast packets received
-zhmc_nic_broadcast_packets_sent_count            D     Number of broadcast packets sent
-zhmc_nic_broadcast_packets_received_count        D     Number of broadcast packets received
-zhmc_nic_data_sent_bytes                         D     Amount of data sent over the collection interval
-zhmc_nic_data_received_bytes                     D     Amount of data received over the collection interval
-zhmc_nic_data_rate_sent_bytes_per_second         D     Data rate sent over the collection interval
-zhmc_nic_data_rate_received_bytes_per_second     D     Data rate received over the collection interval
-zhmc_cpc_humidity_percent                        C+D   Relative humidity
-zhmc_cpc_dew_point_celsius                       C+D   Dew point
-zhmc_cpc_heat_load_total_btu_per_hour            C+D   Total heat load of the CPC
-zhmc_cpc_heat_load_forced_air_btu_per_hour       C+D   Heat load of the CPC covered by forced-air
-zhmc_cpc_heat_load_water_btu_per_hour            C+D   Heat load of the CPC covered by water
-zhmc_cpc_exhaust_temperature_celsius             C+D   Exhaust temperature of the CPC
-zhmc_cpc_power_cord1_phase_a_watts               C+D   Power in Phase A of line cord 1 - 0 if not available
-zhmc_cpc_power_cord1_phase_b_watts               C+D   Power in Phase B of line cord 1 - 0 if not available
-zhmc_cpc_power_cord1_phase_c_watts               C+D   Power in Phase C of line cord 1 - 0 if not available
-zhmc_cpc_power_cord2_phase_a_watts               C+D   Power in Phase A of line cord 2 - 0 if not available
-zhmc_cpc_power_cord2_phase_b_watts               C+D   Power in Phase B of line cord 2 - 0 if not available
-zhmc_cpc_power_cord2_phase_c_watts               C+D   Power in Phase C of line cord 2 - 0 if not available
-zhmc_cpc_power_cord3_phase_a_watts               C+D   Power in Phase A of line cord 3 - 0 if not available
-zhmc_cpc_power_cord3_phase_b_watts               C+D   Power in Phase B of line cord 3 - 0 if not available
-zhmc_cpc_power_cord3_phase_c_watts               C+D   Power in Phase C of line cord 3 - 0 if not available
-zhmc_cpc_power_cord4_phase_a_watts               C+D   Power in Phase A of line cord 4 - 0 if not available
-zhmc_cpc_power_cord4_phase_b_watts               C+D   Power in Phase B of line cord 4 - 0 if not available
-zhmc_cpc_power_cord4_phase_c_watts               C+D   Power in Phase C of line cord 4 - 0 if not available
-zhmc_cpc_power_cord5_phase_a_watts               C+D   Power in Phase A of line cord 5 - 0 if not available
-zhmc_cpc_power_cord5_phase_b_watts               C+D   Power in Phase B of line cord 5 - 0 if not available
-zhmc_cpc_power_cord5_phase_c_watts               C+D   Power in Phase C of line cord 5 - 0 if not available
-zhmc_cpc_power_cord6_phase_a_watts               C+D   Power in Phase A of line cord 6 - 0 if not available
-zhmc_cpc_power_cord6_phase_b_watts               C+D   Power in Phase B of line cord 6 - 0 if not available
-zhmc_cpc_power_cord6_phase_c_watts               C+D   Power in Phase C of line cord 6 - 0 if not available
-zhmc_cpc_power_cord7_phase_a_watts               C+D   Power in Phase A of line cord 7 - 0 if not available
-zhmc_cpc_power_cord7_phase_b_watts               C+D   Power in Phase B of line cord 7 - 0 if not available
-zhmc_cpc_power_cord7_phase_c_watts               C+D   Power in Phase C of line cord 7 - 0 if not available
-zhmc_cpc_power_cord8_phase_a_watts               C+D   Power in Phase A of line cord 8 - 0 if not available
-zhmc_cpc_power_cord8_phase_b_watts               C+D   Power in Phase B of line cord 8 - 0 if not available
-zhmc_cpc_power_cord8_phase_c_watts               C+D   Power in Phase C of line cord 8 - 0 if not available
-zhmc_processor_usage_ratio                       C+D   Usage ratio of the processor
-zhmc_processor_smt_mode_percent                  C+D   Percentage of time the processor was in in SMT mode
-zhmc_processor_smt_thread0_usage_ratio           C+D   Usage ratio of thread 0 of the processor when in SMT mode
-zhmc_processor_smt_thread1_usage_ratio           C+D   Usage ratio of thread 1 of the processor when in SMT mode
-===============================================  ====  ==================================================================
+======================================================  ====  ==================================================================
+Prometheus Metric                                       Mode  Description
+======================================================  ====  ==================================================================
+
+zhmc_cpc_cp_processor_count                             C+D   Number of active CP processors
+zhmc_cpc_ifl_processor_count                            C+D   Number of active IFL processors
+zhmc_cpc_icf_processor_count                            C+D   Number of active ICF processors
+zhmc_cpc_iip_processor_count                            C+D   Number of active zIIP processors
+zhmc_cpc_aap_processor_count                            C+D   Number of active zAAP processors
+zhmc_cpc_cbp_processor_count                            C+D   Number of active CBP processors
+zhmc_cpc_sap_processor_count                            C+D   Number of active SAP processors
+zhmc_cpc_defective_processor_count                      C+D   Number of defective processors of all processor types
+zhmc_cpc_spare_processor_count                          C+D   Number of spare processors of all processor types
+zhmc_cpc_total_memory_mib                               C+D   Total amount of installed memory, in MiB
+zhmc_cpc_hsa_memory_mib                                 C+D   Memory reserved for the base hardware system area (HSA), in MiB
+zhmc_cpc_partition_memory_mib                           C+D   Memory for use by partitions, in MiB
+zhmc_cpc_partition_central_memory_mib                   C+D   Memory allocated as central storage across the active partitions, in MiB
+zhmc_cpc_partition_expanded_memory_mib                  C+D   Memory allocated as expanded storage across the active partitions, in MiB
+zhmc_cpc_available_memory_mib                           C+D   Memory not allocated to active partitions, in MiB
+zhmc_cpc_vfm_increment_gib                              C+D   Increment size of VFM, in GiB
+zhmc_cpc_total_vfm_gib                                  C+D   Total amount of installed VFM, in GiB
+zhmc_cpc_processor_usage_ratio                          C+D   Usage ratio across all processors of the CPC
+zhmc_cpc_shared_processor_usage_ratio                   C+D   Usage ratio across all shared processors of the CPC
+zhmc_cpc_dedicated_processor_usage_ratio                C     Usage ratio across all dedicated processors of the CPC
+zhmc_cpc_cp_processor_usage_ratio                       C+D   Usage ratio across all CP processors of the CPC
+zhmc_cpc_cp_shared_processor_usage_ratio                C+D   Usage ratio across all shared CP processors of the CPC
+zhmc_cpc_cp_dedicated_processor_usage_ratio             C     Usage ratio across all dedicated CP processors of the CPC
+zhmc_cpc_ifl_processor_usage_ratio                      C+D   Usage ratio across all IFL processors of the CPC
+zhmc_cpc_ifl_shared_processor_usage_ratio               C+D   Usage ratio across all shared IFL processors of the CPC
+zhmc_cpc_ifl_dedicated_processor_usage_ratio            C     Usage ratio across all dedicated IFL processors of the CPC
+zhmc_cpc_aap_shared_processor_usage_ratio               C     Usage ratio across all shared zAAP processors of the CPC
+zhmc_cpc_aap_dedicated_processor_usage_ratio            C     Usage ratio across all dedicated zAAP processors of the CPC
+zhmc_cpc_cbp_processor_usage_ratio                      C     Usage ratio across all CBP processors of the CPC
+zhmc_cpc_cbp_shared_processor_usage_ratio               C     Usage ratio across all shared CBP processors of the CPC
+zhmc_cpc_cbp_dedicated_processor_usage_ratio            C     Usage ratio across all dedicated CBP processors of the CPC
+zhmc_cpc_icf_processor_usage_ratio                      C     Usage ratio across all ICF processors of the CPC
+zhmc_cpc_icf_shared_processor_usage_ratio               C     Usage ratio across all shared ICF processors of the CPC
+zhmc_cpc_icf_dedicated_processor_usage_ratio            C     Usage ratio across all dedicated ICF processors of the CPC
+zhmc_cpc_iip_processor_usage_ratio                      C     Usage ratio across all zIIP processors of the CPC
+zhmc_cpc_iip_shared_processor_usage_ratio               C     Usage ratio across all shared zIIP processors of the CPC
+zhmc_cpc_iip_dedicated_processor_usage_ratio            C     Usage ratio across all dedicated zIIP processors of the CPC
+zhmc_cpc_channel_usage_ratio                            C     Usage ratio across all channels of the CPC
+zhmc_cpc_accelerator_adapter_usage_ratio                D     Usage ratio across all accelerator adapters of the CPC
+zhmc_cpc_crypto_adapter_usage_ratio                     D     Usage ratio across all crypto adapters of the CPC
+zhmc_cpc_network_adapter_usage_ratio                    D     Usage ratio across all network adapters of the CPC
+zhmc_cpc_storage_adapter_usage_ratio                    D     Usage ratio across all storage adapters of the CPC
+zhmc_cpc_power_watts                                    C+D   Power consumption of the CPC
+zhmc_cpc_ambient_temperature_celsius                    C+D   Ambient temperature of the CPC
+zhmc_cpc_humidity_percent                               C+D   Relative humidity
+zhmc_cpc_dew_point_celsius                              C+D   Dew point
+zhmc_cpc_heat_load_total_btu_per_hour                   C+D   Total heat load of the CPC
+zhmc_cpc_heat_load_forced_air_btu_per_hour              C+D   Heat load of the CPC covered by forced-air
+zhmc_cpc_heat_load_water_btu_per_hour                   C+D   Heat load of the CPC covered by water
+zhmc_cpc_exhaust_temperature_celsius                    C+D   Exhaust temperature of the CPC
+zhmc_cpc_power_cord1_phase_a_watts                      C+D   Power in Phase A of line cord 1 - 0 if not available
+zhmc_cpc_power_cord1_phase_b_watts                      C+D   Power in Phase B of line cord 1 - 0 if not available
+zhmc_cpc_power_cord1_phase_c_watts                      C+D   Power in Phase C of line cord 1 - 0 if not available
+zhmc_cpc_power_cord2_phase_a_watts                      C+D   Power in Phase A of line cord 2 - 0 if not available
+zhmc_cpc_power_cord2_phase_b_watts                      C+D   Power in Phase B of line cord 2 - 0 if not available
+zhmc_cpc_power_cord2_phase_c_watts                      C+D   Power in Phase C of line cord 2 - 0 if not available
+zhmc_cpc_power_cord3_phase_a_watts                      C+D   Power in Phase A of line cord 3 - 0 if not available
+zhmc_cpc_power_cord3_phase_b_watts                      C+D   Power in Phase B of line cord 3 - 0 if not available
+zhmc_cpc_power_cord3_phase_c_watts                      C+D   Power in Phase C of line cord 3 - 0 if not available
+zhmc_cpc_power_cord4_phase_a_watts                      C+D   Power in Phase A of line cord 4 - 0 if not available
+zhmc_cpc_power_cord4_phase_b_watts                      C+D   Power in Phase B of line cord 4 - 0 if not available
+zhmc_cpc_power_cord4_phase_c_watts                      C+D   Power in Phase C of line cord 4 - 0 if not available
+zhmc_cpc_power_cord5_phase_a_watts                      C+D   Power in Phase A of line cord 5 - 0 if not available
+zhmc_cpc_power_cord5_phase_b_watts                      C+D   Power in Phase B of line cord 5 - 0 if not available
+zhmc_cpc_power_cord5_phase_c_watts                      C+D   Power in Phase C of line cord 5 - 0 if not available
+zhmc_cpc_power_cord6_phase_a_watts                      C+D   Power in Phase A of line cord 6 - 0 if not available
+zhmc_cpc_power_cord6_phase_b_watts                      C+D   Power in Phase B of line cord 6 - 0 if not available
+zhmc_cpc_power_cord6_phase_c_watts                      C+D   Power in Phase C of line cord 6 - 0 if not available
+zhmc_cpc_power_cord7_phase_a_watts                      C+D   Power in Phase A of line cord 7 - 0 if not available
+zhmc_cpc_power_cord7_phase_b_watts                      C+D   Power in Phase B of line cord 7 - 0 if not available
+zhmc_cpc_power_cord7_phase_c_watts                      C+D   Power in Phase C of line cord 7 - 0 if not available
+zhmc_cpc_power_cord8_phase_a_watts                      C+D   Power in Phase A of line cord 8 - 0 if not available
+zhmc_cpc_power_cord8_phase_b_watts                      C+D   Power in Phase B of line cord 8 - 0 if not available
+zhmc_cpc_power_cord8_phase_c_watts                      C+D   Power in Phase C of line cord 8 - 0 if not available
+
+zhmc_processor_usage_ratio                              C+D   Usage ratio of the processor
+zhmc_processor_smt_mode_percent                         C+D   Percentage of time the processor was in in SMT mode
+zhmc_processor_smt_thread0_usage_ratio                  C+D   Usage ratio of thread 0 of the processor when in SMT mode
+zhmc_processor_smt_thread1_usage_ratio                  C+D   Usage ratio of thread 1 of the processor when in SMT mode
+
+zhmc_partition_processor_usage_ratio                    C+D   Usage ratio across all processors of the partition
+zhmc_partition_cp_processor_usage_ratio                 C     Usage ratio across all CP processors of the partition
+zhmc_partition_ifl_processor_usage_ratio                C     Usage ratio across all IFL processors of the partition
+zhmc_partition_icf_processor_usage_ratio                C     Usage ratio across all ICF processors of the partition
+zhmc_partition_cbp_processor_usage_ratio                C     Usage ratio across all CBP processors of the partition
+zhmc_partition_iip_processor_usage_ratio                C     Usage ratio across all IIP processors of the partition
+zhmc_partition_accelerator_adapter_usage_ratio          D     Usage ratio of all accelerator adapters of the partition
+zhmc_partition_crypto_adapter_usage_ratio               D     Usage ratio of all crypto adapters of the partition
+zhmc_partition_network_adapter_usage_ratio              D     Usage ratio of all network adapters of the partition
+zhmc_partition_storage_adapter_usage_ratio              D     Usage ratio of all storage adapters of the partition
+zhmc_partition_zvm_paging_rate_pages_per_second         C     z/VM paging rate in pages/sec
+zhmc_partition_processor_mode_int                       C+D   Allocation mode for processors as an integer (0=shared, 1=dedicated)
+zhmc_partition_threads_per_processor_ratio              D     Number of threads per processor used by OS
+zhmc_partition_defined_capacity_msu_per_hour            C     Defined capacity expressed in terms of MSU per hour
+zhmc_partition_workload_manager_is_enabled              C     Boolean indicating whether z/OS WLM is allowed to change processing weight related properties
+zhmc_partition_cp_processor_count                       C+D   Number of CP processors allocated to the active partition
+zhmc_partition_cp_processor_count_is_capped             C+D   Boolean indicating whether absolute capping is enabled for CP processors
+zhmc_partition_cp_processor_count_cap                   C+D   Maximum number of CP processors that can be used if absolute capping is enabled, else 0
+zhmc_partition_cp_reserved_processor_count              C     Number of CP processors reserved for the active partition
+zhmc_partition_cp_initial_processing_weight             C+D   Initial CP processing weight for the active partition in shared mode
+zhmc_partition_cp_minimum_processing_weight             C+D   Minimum CP processing weight for the active partition in shared mode
+zhmc_partition_cp_maximum_processing_weight             C+D   Maximum CP processing weight for the active partition in shared mode
+zhmc_partition_cp_current_processing_weight             C+D   Current CP processing weight for the active partition in shared mode
+zhmc_partition_cp_processor_count_cap                   D     Maximum number of CP processors to be used when absolute CP processor capping is enabled
+zhmc_partition_cp_initial_processing_weight_is_capped   C+D   Boolean indicating whether the initial CP processing weight is capped or not
+zhmc_partition_cp_current_processing_weight_is_capped   C     Boolean indicating whether the current CP processing weight is capped or not
+zhmc_partition_ifl_processor_count                      C+D   Number of IFL processors allocated to the active partition
+zhmc_partition_ifl_processor_count_is_capped            C+D   Boolean indicating whether absolute capping is enabled for IFL processors
+zhmc_partition_ifl_processor_count_cap                  C+D   Maximum number of IFL processors that can be used if absolute capping is enabled, else 0
+zhmc_partition_ifl_reserved_processor_count             C     Number of IFL processors reserved for the active partition
+zhmc_partition_ifl_initial_processing_weight            C+D   Initial IFL processing weight for the active partition in shared mode
+zhmc_partition_ifl_minimum_processing_weight            C+D   Minimum IFL processing weight for the active partition in shared mode
+zhmc_partition_ifl_maximum_processing_weight            C+D   Maximum IFL processing weight for the active partition in shared mode
+zhmc_partition_ifl_current_processing_weight            C+D   Current IFL processing weight for the active partition in shared mode
+zhmc_partition_ifl_processor_count_cap                  D     Maximum number of IFL processors to be used when absolute IFL processor capping is enabled
+zhmc_partition_ifl_initial_processing_weight_is_capped  C+D   Boolean indicating whether the initial IFL processing weight is capped or not
+zhmc_partition_ifl_current_processing_weight_is_capped  C     Boolean indicating whether the current IFL processing weight is capped or not
+zhmc_partition_icf_processor_count                      C     Number of ICF processors currently allocated to the active partition
+zhmc_partition_icf_processor_count_is_capped            C     Boolean indicating whether absolute capping is enabled for ICF processors
+zhmc_partition_icf_processor_count_cap                  C     Maximum number of ICF processors that can be used if absolute capping is enabled, else 0
+zhmc_partition_icf_reserved_processor_count             C     Number of ICF processors reserved for the active partition
+zhmc_partition_icf_initial_processing_weight            C     Initial ICF processing weight for the active partition in shared mode
+zhmc_partition_icf_minimum_processing_weight            C     Minimum ICF processing weight for the active partition in shared mode
+zhmc_partition_icf_maximum_processing_weight            C     Maximum ICF processing weight for the active partition in shared mode
+zhmc_partition_icf_current_processing_weight            C     Current ICF processing weight for the active partition in shared mode
+zhmc_partition_icf_initial_processing_weight_is_capped  C     Boolean indicating whether the initial ICF processing weight is capped or not
+zhmc_partition_icf_current_processing_weight_is_capped  C     Boolean indicating whether the current ICF processing weight is capped or not
+zhmc_partition_iip_processor_count                      C     Number of zIIP processors currently allocated to the active partition
+zhmc_partition_iip_processor_count_is_capped            C     Boolean indicating whether absolute capping is enabled for zIIP processors
+zhmc_partition_iip_processor_count_cap                  C     Maximum number of zIIP processors that can be used if absolute capping is enabled, else 0
+zhmc_partition_iip_reserved_processor_count             C     Number of zIIP processors reserved for the active partition
+zhmc_partition_iip_initial_processing_weight            C     Initial zIIP processing weight for the active partition in shared mode
+zhmc_partition_iip_minimum_processing_weight            C     Minimum zIIP processing weight for the active partition in shared mode
+zhmc_partition_iip_maximum_processing_weight            C     Maximum zIIP processing weight for the active partition in shared mode
+zhmc_partition_iip_current_processing_weight            C     Current zIIP processing weight for the active partition in shared mode
+zhmc_partition_iip_initial_processing_weight_is_capped  C     Boolean indicating whether the initial zIIP processing weight is capped or not
+zhmc_partition_iip_current_processing_weight_is_capped  C     Boolean indicating whether the current zIIP processing weight is capped or not
+zhmc_partition_aap_processor_count_is_capped            C     Boolean indicating whether absolute capping is enabled for zAAP processors
+zhmc_partition_aap_processor_count_cap                  C     Maximum number of zAAP processors that can be used if absolute capping is enabled, else 0
+zhmc_partition_aap_initial_processing_weight            C     Initial zAAP processing weight for the active partition in shared mode
+zhmc_partition_aap_minimum_processing_weight            C     Minimum zAAP processing weight for the active partition in shared mode
+zhmc_partition_aap_maximum_processing_weight            C     Maximum zAAP processing weight for the active partition in shared mode
+zhmc_partition_aap_current_processing_weight            C     Current zAAP processing weight for the active partition in shared mode
+zhmc_partition_aap_initial_processing_weight_is_capped  C     Boolean indicating whether the initial zAAP processing weight is capped or not
+zhmc_partition_aap_current_processing_weight_is_capped  C     Boolean indicating whether the current zAAP processing weight is capped or not
+zhmc_partition_cbp_processor_count_is_capped            C     Boolean indicating whether absolute capping is enabled for CBP processors
+zhmc_partition_cbp_processor_count_cap                  C     Maximum number of CBP processors that can be used if absolute capping is enabled, else 0
+zhmc_partition_cbp_initial_processing_weight            C     Initial CBP processing weight for the active partition in shared mode
+zhmc_partition_cbp_minimum_processing_weight            C     Minimum CBP processing weight for the active partition in shared mode
+zhmc_partition_cbp_maximum_processing_weight            C     Maximum CBP processing weight for the active partition in shared mode
+zhmc_partition_cbp_current_processing_weight            C     Current CBP processing weight for the active partition in shared mode
+zhmc_partition_cbp_initial_processing_weight_is_capped  C     Boolean indicating whether the initial CBP processing weight is capped or not
+zhmc_partition_cbp_current_processing_weight_is_capped  C     Boolean indicating whether the current CBP processing weight is capped or not
+zhmc_partition_initial_memory_mib                       D     Initial amount of memory allocated to the partition when it becomes active, in MiB
+zhmc_partition_reserved_memory_mib                      D     Amount of reserved memory (maximum memory minus initial memory), in MiB
+zhmc_partition_maximum_memory_mib                       D     Maximum amount of memory to which the OS can increase, in MiB
+zhmc_partition_initial_central_memory_mib               C     Amount of central memory initially allocated to the active partition in MiB, else 0
+zhmc_partition_current_central_memory_mib               C     Amount of central memory currently allocated to the active partition, in MiB, else 0
+zhmc_partition_maximum_central_memory_mib               C     Maximum amount of central memory to which the operating system running in the active partition can increase, in MiB
+zhmc_partition_initial_expanded_memory_mib              C     Amount of expanded memory initially allocated to the active partition in MiB, else 0
+zhmc_partition_current_expanded_memory_mib              C     Amount of expanded memory currently allocated to the active partition, in MiB, else 0
+zhmc_partition_maximum_expanded_memory_mib              C     Maximum amount of expanded memory to which the operating system running in the active partition can increase, in MiB
+zhmc_partition_initial_vfm_memory_gib                   C     Initial amount of VFM memory to be allocated at partition activation, in GiB
+zhmc_partition_maximum_vfm_memory_gib                   C     Maximum amount of VFM memory that can be allocated to the active partition, in GiB
+zhmc_partition_current_vfm_memory_gib                   C     Current amount of VFM memory that is allocated to the active partition, in GiB
+
+zhmc_crypto_adapter_usage_ratio                         C     Usage ratio of the crypto adapter
+zhmc_flash_memory_adapter_usage_ratio                   C     Usage ratio of the flash memory adapter
+zhmc_adapter_usage_ratio                                D     Usage ratio of the adapter
+zhmc_channel_usage_ratio                                C     Usage ratio of the channel
+zhmc_roce_adapter_usage_ratio                           C     Usage ratio of the RoCE adapter
+zhmc_port_bytes_sent_count                              D     Number of Bytes in unicast packets that were sent
+zhmc_port_bytes_received_count                          D     Number of Bytes in unicast packets that were received
+zhmc_port_packets_sent_count                            D     Number of unicast packets that were sent
+zhmc_port_packets_received_count                        D     Number of unicast packets that were received
+zhmc_port_packets_sent_dropped_count                    D     Number of sent packets that were dropped (resource shortage)
+zhmc_port_packets_received_dropped_count                D     Number of received packets that were dropped (resource shortage)
+zhmc_port_packets_sent_discarded_count                  D     Number of sent packets that were discarded (malformed)
+zhmc_port_packets_received_discarded_count              D     Number of received packets that were discarded (malformed)
+zhmc_port_multicast_packets_sent_count                  D     Number of multicast packets sent
+zhmc_port_multicast_packets_received_count              D     Number of multicast packets received
+zhmc_port_broadcast_packets_sent_count                  D     Number of broadcast packets sent
+zhmc_port_broadcast_packets_received_count              D     Number of broadcast packets received
+zhmc_port_data_sent_bytes                               D     Amount of data sent over the collection interval
+zhmc_port_data_received_bytes                           D     Amount of data received over the collection interval
+zhmc_port_data_rate_sent_bytes_per_second               D     Data rate sent over the collection interval
+zhmc_port_data_rate_received_bytes_per_second           D     Data rate received over the collection interval
+zhmc_port_bandwidth_usage_ratio                         D     Bandwidth usage ratio of the port
+
+zhmc_nic_bytes_sent_count                               D     Number of Bytes in unicast packets that were sent
+zhmc_nic_bytes_received_count                           D     Number of Bytes in unicast packets that were received
+zhmc_nic_packets_sent_count                             D     Number of unicast packets that were sent
+zhmc_nic_packets_received_count                         D     Number of unicast packets that were received
+zhmc_nic_packets_sent_dropped_count                     D     Number of sent packets that were dropped (resource shortage)
+zhmc_nic_packets_received_dropped_count                 D     Number of received packets that were dropped (resource shortage)
+zhmc_nic_packets_sent_discarded_count                   D     Number of sent packets that were discarded (malformed)
+zhmc_nic_packets_received_discarded_count               D     Number of received packets that were discarded (malformed)
+zhmc_nic_multicast_packets_sent_count                   D     Number of multicast packets sent
+zhmc_nic_multicast_packets_received_count               D     Number of multicast packets received
+zhmc_nic_broadcast_packets_sent_count                   D     Number of broadcast packets sent
+zhmc_nic_broadcast_packets_received_count               D     Number of broadcast packets received
+zhmc_nic_data_sent_bytes                                D     Amount of data sent over the collection interval
+zhmc_nic_data_received_bytes                            D     Amount of data received over the collection interval
+zhmc_nic_data_rate_sent_bytes_per_second                D     Data rate sent over the collection interval
+zhmc_nic_data_rate_received_bytes_per_second            D     Data rate received over the collection interval
+
+======================================================  ====  ==================================================================
 
 HMC credentials file
 --------------------
@@ -462,12 +583,23 @@ The metric definition file is in YAML format and has the following structure:
             value: {label-value}
 
     metrics:
-      # dictionary of metric groups and metrics
+      # dictionary of metric groups:
       {hmc-metric-group}:
+
+        # dictionary format for defining metrics:
         {hmc-metric}:
-          percent: {percent-bool}
           exporter_name: {metric}_{unit}
           exporter_desc: {help}
+          percent: {percent-bool}
+          valuemap: {valuemap}
+
+        # list format for defining metrics:
+        - property_name: {hmc-metric}                     # either this
+          properties_expression: {properties-expression}  # or this
+          exporter_name: {metric}_{unit}
+          exporter_desc: {help}
+          percent: {percent-bool}
+          valuemap: {valuemap}
 
 Where:
 
@@ -508,7 +640,7 @@ Where:
     that are inside of the CPC at the second level, such as NICs or adapter
     ports, to get back to the CPC containing them.
 
-  - ``{hmc-metric-name}`` the name of the HMC metric within the same metric
+  - ``{hmc-metric}`` the name of the HMC metric within the same metric
     group whose metric value should be used as a label value. This can be used
     to use accompanying HMC metrics that are actually identifiers for resources,
     a labels for the actual metric. Example: The HMC returns metrics group
@@ -535,10 +667,20 @@ Where:
               exporter_name: usage_ratio
               exporter_desc: Usage ratio of the channel
 
+* ``{properties-expression}`` is a Jinja2 expression whose value should be used
+  is as the metric value, for resource based metrics. The expression uses
+  the variable ``properties`` which is the resource properties dictionary of the
+  resource. The ``properties_expression`` attribute is mutually exclusive with
+  ``property_name``.
+
 * ``{percent-bool}`` is a boolean indicating whether the metric value should
   be divided by 100. The reason for this is that the HMC metrics represent
   percentages such that a value of 100 means 100% = 1, while Prometheus
   represents them such that a value of 1.0 means 100% = 1.
+
+* ``{valuemap}`` is an optional dictionary for mapping string enumeration values
+  in the original HMC value to integers to be exported to Prometheus. This is
+  used for example for the processor mode (shared, dedicated).
 
 * ``{metric}_{unit}`` is the Prometheus local metric name and unit in
   the full metric name ``zhmc_{resource-type}_{metric}_{unit}``.
@@ -655,3 +797,40 @@ Examples:
 At this point, only the HMC interactions can be logged, so the only valid value
 for the ``--log-comp`` option is ``hmc``. That is also the default component
 that is logged (when enabled via ``--log-dest``).
+
+
+Performance
+-----------
+
+The support for resource property based metric values that was introduced in
+version 0.8 has slowed down the startup of the exporter quite significantly if
+these metrics are enabled.
+
+Here is an elapsed time measurement for the startup of the exporter using an HMC
+in one of our development data centers:
+
+* 11:33 min for preparing auto-update for 143 partitions on two z14 systems in classic mode
+* 0:12 min for preparing auto-update for 98 partitions on two z13 systems in DPM mode
+* 1:30 min for preparing auto-update for the 4 CPCs
+* 10:25 min for all other startup activities (without the
+  partition-attached-network-interface metrics group that would have been 0:48 min)
+
+Once the exporter is up and running, the fetching of metrics by Prometheus from
+the exporter is very fast:
+
+* 0:00.35 min (=350 ms) for fetching metrics with 236 HELP/TYPE lines and 5269
+  metric value lines (size: 500 KB)
+
+In this measurement, the complete set of metrics was enabled for the 4 CPCs
+described above.
+
+This result includes metric values from properties of auto-updated resources
+(which are maintained in the exporter and are updated asynchronously via
+notifications the exporter receives from the HMC) and metric values retrieved
+from the HMC metric service by executing a single HMC operation
+("Get Metric Context").
+
+This was measured with a local web browser that was directed to an exporter
+running on the same local system (a MacBook Pro). The network path between the
+exporter and the targeted HMC went via VPN to the IBM Intranet (via WLAN and
+Internet) and then across a boundary firewall.

--- a/examples/metrics.yaml
+++ b/examples/metrics.yaml
@@ -61,6 +61,17 @@ metric_groups:
       - name: adapter_pchid
         value: channel-id
 
+  logical-partition-resource:
+    type: resource
+    resource: cpc.logical-partition
+    prefix: partition
+    fetch: true
+    labels:
+      - name: cpc
+        value: resource.parent
+      - name: partition
+        value: resource
+
   # Available for CPCs in DPM mode
 
   dpm-system-usage-overview:
@@ -115,6 +126,17 @@ metric_groups:
       - name: nic
         value: resource
 
+  partition-resource:
+    type: resource
+    resource: cpc.partition
+    prefix: partition
+    fetch: true
+    labels:
+      - name: cpc
+        value: resource.parent
+      - name: partition
+        value: resource
+
   # Available for CPCs in any mode
 
   zcpc-environmentals-and-power:
@@ -139,6 +161,15 @@ metric_groups:
     prefix: cpc
     fetch: true
     if: "hmc_version>='2.15.0'"
+    labels:
+      - name: cpc
+        value: resource
+
+  cpc-resource:
+    type: resource
+    resource: cpc
+    prefix: cpc
+    fetch: true
     labels:
       - name: cpc
         value: resource
@@ -218,14 +249,17 @@ metrics:
       exporter_desc: Usage ratio across all dedicated zAAP processors of the CPC
     # aap-all-processor-usage does not seem to exist
     cbp-all-processor-usage:
+      # since HMC/SE version 2.14.0
       percent: true
       exporter_name: cbp_processor_usage_ratio
       exporter_desc: Usage ratio across all CBP processors of the CPC
     cbp-shared-processor-usage:
+      # since HMC/SE version 2.14.0
       percent: true
       exporter_name: cbp_shared_processor_usage_ratio
       exporter_desc: Usage ratio across all shared CBP processors of the CPC
     cbp-dedicated-processor-usage:
+      # since HMC/SE version 2.14.0
       percent: true
       exporter_name: cbp_dedicated_processor_usage_ratio
       exporter_desc: Usage ratio across all dedicated CBP processors of the CPC
@@ -264,6 +298,7 @@ metrics:
       exporter_name: iip_processor_usage_ratio
       exporter_desc: Usage ratio across all IIP processors of the partition
     cbp-processor-usage:
+      # since HMC/SE version 2.14.0
       percent: true
       exporter_name: cbp_processor_usage_ratio
       exporter_desc: Usage ratio across all CBP processors of the partition
@@ -319,6 +354,225 @@ metrics:
       percent: true
       exporter_name: usage_ratio
       exporter_desc: Usage ratio of the RoCE adapter
+
+  logical-partition-resource:  # can be in dictionary or list format
+    - property_name: defined-capacity
+      exporter_name: defined_capacity_msu_per_hour
+      exporter_desc: Defined capacity expressed in terms of Millions of Service Units (MSU)s per hour
+    - property_name: workload-manager-enabled
+      exporter_name: workload_manager_is_enabled
+      exporter_desc: Boolean indicating whether the z/OS Workload Manager is allowed to change processing weight related properties of the partition
+    - property_name: processor-usage
+      exporter_name: processor_mode_int
+      exporter_desc: Allocation mode for processors to the active partition as an integer (0=shared, 1=dedicated)
+      valuemap:
+        shared: 0
+        dedicated: 1
+    - property_name: number-general-purpose-processors
+      exporter_name: cp_processor_count
+      exporter_desc: Number of CP processors currently allocated to the active partition
+    - property_name: number-reserved-general-purpose-processors
+      exporter_name: cp_reserved_processor_count
+      exporter_desc: Number of CP processors reserved for the active partition (this is the maximum when increasing the number)
+    - property_name: initial-processing-weight
+      exporter_name: cp_initial_processing_weight
+      exporter_desc: Initial CP processing weight for the active partition in shared mode (1..999)
+    - property_name: minimum-processing-weight
+      exporter_name: cp_minimum_processing_weight
+      exporter_desc: Minimum CP processing weight for the active partition in shared mode (1..999)
+    - property_name: maximum-processing-weight
+      exporter_name: cp_maximum_processing_weight
+      exporter_desc: Maximum CP processing weight for the active partition in shared mode (1..999)
+    - property_name: current-processing-weight
+      exporter_name: cp_current_processing_weight
+      exporter_desc: Current CP processing weight for the active partition in shared mode (1..999)
+    - properties_expression: "properties['absolute-processing-capping'].type == 'processor'"
+      exporter_name: cp_processor_count_is_capped
+      exporter_desc: Boolean indicating whether absolute capping is enabled for CP processors
+    - properties_expression: "properties['absolute-processing-capping'].value if properties['absolute-processing-capping'].type == 'processor' else 0"
+      exporter_name: cp_processor_count_cap
+      exporter_desc: Maximum number of CP processors that can be used if absolute capping is enabled, else 0
+    - property_name: initial-processing-weight-capped
+      exporter_name: cp_initial_processing_weight_is_capped
+      exporter_desc: Boolean indicating whether the initial CP processing weight is capped
+    - property_name: current-processing-weight-capped
+      exporter_name: cp_current_processing_weight_is_capped
+      exporter_desc: Boolean indicating whether the current CP processing weight is capped
+    - property_name: number-ifl-processors
+      exporter_name: ifl_processor_count
+      exporter_desc: Number of IFL processors currently allocated to the active partition
+    - property_name: number-reserved-ifl-processors
+      exporter_name: ifl_reserved_processor_count
+      exporter_desc: Number of IFL processors reserved for the active partition (this is the maximum when increasing the number)
+    - property_name: initial-ifl-processing-weight
+      exporter_name: ifl_initial_processing_weight
+      exporter_desc: Initial IFL processing weight for the active partition in shared mode (1..999)
+    - property_name: minimum-ifl-processing-weight
+      exporter_name: ifl_minimum_processing_weight
+      exporter_desc: Minimum IFL processing weight for the active partition in shared mode (1..999)
+    - property_name: maximum-ifl-processing-weight
+      exporter_name: ifl_maximum_processing_weight
+      exporter_desc: Maximum IFL processing weight for the active partition in shared mode (1..999)
+    - property_name: current-ifl-processing-weight
+      exporter_name: ifl_current_processing_weight
+      exporter_desc: Current IFL processing weight for the active partition in shared mode (1..999)
+    - properties_expression: "properties['absolute-ifl-capping'].type == 'processor'"
+      exporter_name: ifl_processor_count_is_capped
+      exporter_desc: Boolean indicating whether absolute capping is enabled for IFL processors
+    - properties_expression: "properties['absolute-ifl-capping'].value if properties['absolute-ifl-capping'].type == 'processor' else 0"
+      exporter_name: ifl_processor_count_cap
+      exporter_desc: Maximum number of IFL processors that can be used if absolute capping is enabled, else 0
+    - property_name: initial-ifl-processing-weight-capped
+      exporter_name: ifl_initial_processing_weight_is_capped
+      exporter_desc: Boolean indicating whether the initial IFL processing weight is capped
+    - property_name: current-ifl-processing-weight-capped
+      exporter_name: ifl_current_processing_weight_is_capped
+      exporter_desc: Boolean indicating whether the current IFL processing weight is capped
+    - property_name: number-icf-processors
+      exporter_name: icf_processor_count
+      exporter_desc: Number of ICF processors currently allocated to the active partition
+    - property_name: number-reserved-icf-processors
+      exporter_name: icf_reserved_processor_count
+      exporter_desc: Number of ICF processors reserved for the active partition (this is the maximum when increasing the number)
+    - property_name: initial-cf-processing-weight
+      exporter_name: icf_initial_processing_weight
+      exporter_desc: Initial ICF processing weight for the active partition in shared mode (1..999)
+    - property_name: minimum-cf-processing-weight
+      exporter_name: icf_minimum_processing_weight
+      exporter_desc: Minimum ICF processing weight for the active partition in shared mode (1..999)
+    - property_name: maximum-cf-processing-weight
+      exporter_name: icf_maximum_processing_weight
+      exporter_desc: Maximum ICF processing weight for the active partition in shared mode (1..999)
+    - property_name: current-cf-processing-weight
+      exporter_name: icf_current_processing_weight
+      exporter_desc: Current ICF processing weight for the active partition in shared mode (1..999)
+    - properties_expression: "properties['absolute-cf-capping'].type == 'processor'"
+      exporter_name: icf_processor_count_is_capped
+      exporter_desc: Boolean indicating whether absolute capping is enabled for ICF processors
+    - properties_expression: "properties['absolute-cf-capping'].value if properties['absolute-cf-capping'].type == 'processor' else 0"
+      exporter_name: icf_processor_count_cap
+      exporter_desc: Maximum number of ICF processors that can be used if absolute capping is enabled, else 0
+    - property_name: initial-cf-processing-weight-capped
+      exporter_name: icf_initial_processing_weight_is_capped
+      exporter_desc: Boolean indicating whether the initial ICF processing weight is capped
+    - property_name: current-cf-processing-weight-capped
+      exporter_name: icf_current_processing_weight_is_capped
+      exporter_desc: Boolean indicating whether the current ICF processing weight is capped
+    - property_name: number-ziip-processors
+      exporter_name: iip_processor_count
+      exporter_desc: Number of zIIP processors currently allocated to the active partition
+    - property_name: number-reserved-ziip-processors
+      exporter_name: iip_reserved_processor_count
+      exporter_desc: Number of zIIP processors reserved for the active partition (this is the maximum when increasing the number)
+    - property_name: initial-ziip-processing-weight
+      exporter_name: iip_initial_processing_weight
+      exporter_desc: Initial zIIP processing weight for the active partition in shared mode (1..999)
+    - property_name: minimum-ziip-processing-weight
+      exporter_name: iip_minimum_processing_weight
+      exporter_desc: Minimum zIIP processing weight for the active partition in shared mode (1..999)
+    - property_name: maximum-ziip-processing-weight
+      exporter_name: iip_maximum_processing_weight
+      exporter_desc: Maximum zIIP processing weight for the active partition in shared mode (1..999)
+    - property_name: current-ziip-processing-weight
+      exporter_name: iip_current_processing_weight
+      exporter_desc: Current zIIP processing weight for the active partition in shared mode (1..999)
+    - properties_expression: "properties['absolute-ziip-capping'].type == 'processor'"
+      exporter_name: iip_processor_count_is_capped
+      exporter_desc: Boolean indicating whether absolute capping is enabled for zIIP processors
+    - properties_expression: "properties['absolute-ziip-capping'].value if properties['absolute-ziip-capping'].type == 'processor' else 0"
+      exporter_name: iip_processor_count_cap
+      exporter_desc: Maximum number of zIIP processors that can be used if absolute capping is enabled, else 0
+    - property_name: initial-ziip-processing-weight-capped
+      exporter_name: iip_initial_processing_weight_is_capped
+      exporter_desc: Boolean indicating whether the initial zIIP processing weight is capped
+    - property_name: current-ziip-processing-weight-capped
+      exporter_name: iip_current_processing_weight_is_capped
+      exporter_desc: Boolean indicating whether the current zIIP processing weight is capped
+    # Note: number-...-processors/cores properties do not exist in 2.15 for AAP processors
+    - property_name: initial-aap-processing-weight
+      exporter_name: aap_initial_processing_weight
+      exporter_desc: Initial zAAP processing weight for the active partition in shared mode (1..999)
+    - property_name: minimum-aap-processing-weight
+      exporter_name: aap_minimum_processing_weight
+      exporter_desc: Minimum zAAP processing weight for the active partition in shared mode (1..999)
+    - property_name: maximum-aap-processing-weight
+      exporter_name: aap_maximum_processing_weight
+      exporter_desc: Maximum zAAP processing weight for the active partition in shared mode (1..999)
+    - property_name: current-aap-processing-weight
+      exporter_name: aap_current_processing_weight
+      exporter_desc: Current zAAP processing weight for the active partition in shared mode (1..999)
+    - properties_expression: "properties['absolute-aap-capping'].type == 'processor'"
+      exporter_name: aap_processor_count_is_capped
+      exporter_desc: Boolean indicating whether absolute capping is enabled for zAAP processors
+    - properties_expression: "properties['absolute-aap-capping'].value if properties['absolute-aap-capping'].type == 'processor' else 0"
+      exporter_name: aap_processor_count_cap
+      exporter_desc: Maximum number of zAAP processors that can be used if absolute capping is enabled, else 0
+    - property_name: initial-aap-processing-weight-capped
+      exporter_name: aap_initial_processing_weight_is_capped
+      exporter_desc: Boolean indicating whether the initial zAAP processing weight is capped
+    - property_name: current-aap-processing-weight-capped
+      exporter_name: aap_current_processing_weight_is_capped
+      exporter_desc: Boolean indicating whether the current zAAP processing weight is capped
+    # Note: number-...-processors/cores properties do not exist in 2.15 for CBP processors
+    - property_name: initial-cbp-processing-weight
+      # since HMC/SE version 2.14.0
+      exporter_name: cbp_initial_processing_weight
+      exporter_desc: Initial CBP processing weight for the active partition in shared mode (1..999)
+    - property_name: minimum-cbp-processing-weight
+      # since HMC/SE version 2.14.0
+      exporter_name: cbp_minimum_processing_weight
+      exporter_desc: Minimum CBP processing weight for the active partition in shared mode (1..999)
+    - property_name: maximum-cbp-processing-weight
+      # since HMC/SE version 2.14.0
+      exporter_name: cbp_maximum_processing_weight
+      exporter_desc: Maximum CBP processing weight for the active partition in shared mode (1..999)
+    - property_name: current-cbp-processing-weight
+      # since HMC/SE version 2.14.0
+      exporter_name: cbp_current_processing_weight
+      exporter_desc: Current CBP processing weight for the active partition in shared mode (1..999)
+    - properties_expression: "properties['absolute-cbp-capping'].type == 'processor'"
+      # since HMC/SE version 2.14.0
+      exporter_name: cbp_processor_count_is_capped
+      exporter_desc: Boolean indicating whether absolute capping is enabled for CBP processors
+    - properties_expression: "properties['absolute-cbp-capping'].value if properties['absolute-cbp-capping'].type == 'processor' else 0"
+      # since HMC/SE version 2.14.0
+      exporter_name: cbp_processor_count_cap
+      exporter_desc: Maximum number of CBP processors that can be used if absolute capping is enabled, else 0
+    - property_name: initial-cbp-processing-weight-capped
+      # since HMC/SE version 2.14.0
+      exporter_name: cbp_initial_processing_weight_is_capped
+      exporter_desc: Boolean indicating whether the initial CBP processing weight is capped
+    - property_name: current-cbp-processing-weight-capped
+      # since HMC/SE version 2.14.0
+      exporter_name: cbp_current_processing_weight_is_capped
+      exporter_desc: Boolean indicating whether the current CBP processing weight is capped
+    - properties_expression: "properties['storage-central-allocation']|map(attribute='initial')|sum"
+      exporter_name: initial_central_memory_mib
+      exporter_desc: Amount of central memory initially allocated to the active partition in MiB, else 0
+    - properties_expression: "properties['storage-central-allocation']|map(attribute='current')|sum"
+      exporter_name: current_central_memory_mib
+      exporter_desc: Amount of central memory currently allocated to the active partition, in MiB, else 0
+    - properties_expression: "properties['storage-central-allocation']|map(attribute='maximum')|sum"
+      exporter_name: maximum_central_memory_mib
+      exporter_desc: Maximum amount of central memory to which the operating system running in the active partition can increase, in MiB
+    - properties_expression: "properties['storage-expanded-allocation']|map(attribute='initial')|sum"
+      exporter_name: initial_expanded_memory_mib
+      exporter_desc: Amount of expanded memory initially allocated to the active partition in MiB, else 0
+    - properties_expression: "properties['storage-expanded-allocation']|map(attribute='current')|sum"
+      exporter_name: current_expanded_memory_mib
+      exporter_desc: Amount of expanded memory currently allocated to the active partition, in MiB, else 0
+    - properties_expression: "properties['storage-expanded-allocation']|map(attribute='maximum')|sum"
+      exporter_name: maximum_expanded_memory_mib
+      exporter_desc: Maximum amount of expanded memory to which the operating system running in the active partition can increase, in MiB
+    - property_name: initial-vfm-storage
+      exporter_name: initial_vfm_memory_gib
+      exporter_desc: Initial amount of IBM Virtual Flash Memory (VFM) to be allocated at partition activation, in GiB
+    - property_name: maximum-vfm-storage
+      exporter_name: maximum_vfm_memory_gib
+      exporter_desc: Maximum amount of IBM Virtual Flash Memory (VFM) that can be allocated to the active partition, in GiB
+    - property_name: current-vfm-storage
+      exporter_name: current_vfm_memory_gib
+      exporter_desc: Current amount of IBM Virtual Flash Memory (VFM) that is allocated to the active partition, in GiB
 
   # Available for CPCs in DPM mode
 
@@ -585,6 +839,74 @@ metrics:
       exporter_name: null  # Ignored (can be detected from metric values)
       exporter_desc: null
 
+  partition-resource:  # can be in dictionary or list format
+    - property_name: processor-mode
+      exporter_name: processor_mode_int
+      exporter_desc: Allocation mode for processors to the active partition as an integer (0=shared, 1=dedicated)
+      valuemap:
+        shared: 0
+        dedicated: 1
+    - property_name: threads-per-processor
+      exporter_name: threads_per_processor_ratio
+      exporter_desc: Number of threads per allocated processor the operating system running in the partition is configured to use
+    - property_name: cp-processors
+      exporter_name: cp_processor_count
+      exporter_desc: Number of CP processors allocated to the active partition
+    - property_name: initial-cp-processing-weight
+      exporter_name: cp_initial_processing_weight
+      exporter_desc: Initial CP processing weight for the active partition in shared mode (1..999)
+    - property_name: minimum-cp-processing-weight
+      exporter_name: cp_minimum_processing_weight
+      exporter_desc: Minimum CP processing weight for the active partition in shared mode (1..999)
+    - property_name: maximum-cp-processing-weight
+      exporter_name: cp_maximum_processing_weight
+      exporter_desc: Maximum CP processing weight for the active partition in shared mode (1..999)
+    - property_name: current-cp-processing-weight
+      exporter_name: cp_current_processing_weight
+      exporter_desc: Current CP processing weight for the active partition in shared mode (1..999)
+    - properties_expression: "properties['cp-absolute-processor-capping']"
+      exporter_name: cp_processor_count_is_capped
+      exporter_desc: Boolean indicating whether absolute capping is enabled for CP processors
+    - properties_expression: "properties['cp-absolute-processor-capping-value'] if properties['cp-absolute-processor-capping'] else 0"
+      exporter_name: cp_processor_count_cap
+      exporter_desc: Maximum number of CP processors that can be used if absolute capping is enabled, else 0
+    - property_name: cp-processing-weight-capped
+      exporter_name: cp_initial_processing_weight_is_capped
+      exporter_desc: Boolean indicating whether the initial CP processing weight is capped
+    - property_name: ifl-processors
+      exporter_name: ifl_processor_count
+      exporter_desc: Number of IFL processors allocated to the active partition
+    - property_name: initial-ifl-processing-weight
+      exporter_name: ifl_initial_processing_weight
+      exporter_desc: Initial IFL processing weight for the active partition in shared mode (1..999)
+    - property_name: minimum-ifl-processing-weight
+      exporter_name: ifl_minimum_processing_weight
+      exporter_desc: Minimum IFL processing weight for the active partition in shared mode (1..999)
+    - property_name: maximum-ifl-processing-weight
+      exporter_name: ifl_maximum_processing_weight
+      exporter_desc: Maximum IFL processing weight for the active partition in shared mode (1..999)
+    - property_name: current-ifl-processing-weight
+      exporter_name: ifl_current_processing_weight
+      exporter_desc: Current IFL processing weight for the active partition in shared mode (1..999)
+    - properties_expression: "properties['ifl-absolute-processor-capping']"
+      exporter_name: ifl_processor_count_is_capped
+      exporter_desc: Boolean indicating whether absolute capping is enabled for IFL processors
+    - properties_expression: "properties['ifl-absolute-processor-capping-value'] if properties['ifl-absolute-processor-capping'] else 0"
+      exporter_name: ifl_processor_count_cap
+      exporter_desc: Maximum number of IFL processors that can be used if absolute capping is enabled, else 0
+    - property_name: ifl-processing-weight-capped
+      exporter_name: ifl_initial_processing_weight_is_capped
+      exporter_desc: Boolean indicating whether the initial IFL processing weight is capped
+    - property_name: initial-memory
+      exporter_name: initial_memory_mib
+      exporter_desc: Initial amount of memory allocated to the partition when it becomes active, in MiB
+    - property_name: reserved-memory
+      exporter_name: reserved_memory_mib
+      exporter_desc: Amount of reserved memory (maximum memory minus initial memory), in MiB
+    - property_name: maximum-memory
+      exporter_name: maximum_memory_mib
+      exporter_desc: Maximum amount of memory to which the operating system running in the partition can increase the memory allocation, in MiB
+
   # Available for CPCs in any mode
 
   zcpc-environmentals-and-power:
@@ -786,3 +1108,65 @@ metrics:
       percent: true
       exporter_name: smt_thread1_usage_ratio
       exporter_desc: Usage ratio of thread 1 of the processor when in SMT mode - -1 if not supported
+
+  cpc-resource:  # can be in dictionary or list format
+    processor-count-general-purpose:
+      exporter_name: cp_processor_count
+      exporter_desc: Number of active CP processors
+    processor-count-ifl:
+      exporter_name: ifl_processor_count
+      exporter_desc: Number of active IFL processors
+    processor-count-icf:
+      exporter_name: icf_processor_count
+      exporter_desc: Number of active ICF processors
+    processor-count-iip:
+      exporter_name: iip_processor_count
+      exporter_desc: Number of active zIIP processors
+    processor-count-aap:
+      exporter_name: aap_processor_count
+      exporter_desc: Number of active zAAP processors
+    processor-count-cbp:
+      # since HMC/SE version 2.14.0
+      exporter_name: cbp_processor_count
+      exporter_desc: Number of active CBP processors
+    processor-count-service-assist:
+      exporter_name: sap_processor_count
+      exporter_desc: Number of active SAP processors
+    processor-count-defective:
+      exporter_name: defective_processor_count
+      exporter_desc: Number of defective processors of all processor types
+    processor-count-spare:
+      exporter_name: spare_processor_count
+      exporter_desc: Number of spare processors of all processor types
+    storage-total-installed:
+      # since HMC/SE version 2.13.1
+      exporter_name: total_memory_mib
+      exporter_desc: Total amount of installed memory, in MiB
+    storage-hardware-system-area:
+      # since HMC/SE version 2.13.1
+      exporter_name: hsa_memory_mib
+      exporter_desc: Amount of memory reserved for the base hardware system area (HSA), in MiB
+    storage-customer:
+      # since HMC/SE version 2.13.1
+      exporter_name: partition_memory_mib
+      exporter_desc: Amount of memory for use by partitions, in MiB
+    storage-customer-central:
+      # since HMC/SE version 2.13.1
+      exporter_name: partition_central_memory_mib
+      exporter_desc: Amount of memory allocated as central storage across the active partitions, in MiB
+    storage-customer-expanded:
+      # since HMC/SE version 2.13.1
+      exporter_name: partition_expanded_memory_mib
+      exporter_desc: Amount of memory allocated as expanded storage across the active partitions, in MiB
+    storage-customer-available:
+      # since HMC/SE version 2.13.1
+      exporter_name: available_memory_mib
+      exporter_desc: Amount of memory not allocated to active partitions, in MiB
+    storage-vfm-increment-size:
+      # since HMC/SE version 2.14.0
+      exporter_name: vfm_increment_gib
+      exporter_desc: Increment size of IBM Virtual Flash Memory (VFM), in GiB
+    storage-vfm-total:
+      # since HMC/SE version 2.14.0
+      exporter_name: total_vfm_gib
+      exporter_desc: Total amount of installed IBM Virtual Flash Memory (VFM), in GiB

--- a/examples/prometheus.out
+++ b/examples/prometheus.out
@@ -1,576 +1,722 @@
 # HELP zhmc_adapter_usage_ratio Usage ratio of the adapter
 # TYPE zhmc_adapter_usage_ratio gauge
-zhmc_adapter_usage_ratio{adapter="OSM1",cpc="CPCA",pod="wdc04-05"} 0.0
-zhmc_adapter_usage_ratio{adapter="FCP_120_SAN1_02",cpc="CPCA",pod="wdc04-05"} 0.28
-zhmc_adapter_usage_ratio{adapter="FCP_104_SAN1_01",cpc="CPCA",pod="wdc04-05"} 0.01
-zhmc_adapter_usage_ratio{adapter="OSM_12C_PSCN2_08",cpc="CPCA",pod="wdc04-05"} 0.0
-zhmc_adapter_usage_ratio{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05"} 0.0
-zhmc_adapter_usage_ratio{adapter="EP11_13C",cpc="CPCA",pod="wdc04-05"} 0.0
-zhmc_adapter_usage_ratio{adapter="FCP_121_SAN2_02",cpc="CPCA",pod="wdc04-05"} 0.01
-zhmc_adapter_usage_ratio{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05"} 0.0
-zhmc_adapter_usage_ratio{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05"} 0.0
-zhmc_adapter_usage_ratio{adapter="FCP1.D1",cpc="CPCA",pod="wdc04-05"} 0.32
-zhmc_adapter_usage_ratio{adapter="CRYP00",cpc="CPCA",pod="wdc04-05"} 0.0
-zhmc_adapter_usage_ratio{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05"} 0.0
-zhmc_adapter_usage_ratio{adapter="EP11_138",cpc="CPCA",pod="wdc04-05"} 0.0
-zhmc_adapter_usage_ratio{adapter="FCP_124_SAN1_03",cpc="CPCA",pod="wdc04-05"} 0.28
-zhmc_adapter_usage_ratio{adapter="FCP_101_SAN2_00",cpc="CPCA",pod="wdc04-05"} 0.28
-zhmc_adapter_usage_ratio{adapter="FCP_105_SAN2_01",cpc="CPCA",pod="wdc04-05"} 0.28
-zhmc_adapter_usage_ratio{adapter="EP11_11C",cpc="CPCA",pod="wdc04-05"} 0.0
-zhmc_adapter_usage_ratio{adapter="FCP_125_SAN2_03",cpc="CPCA",pod="wdc04-05"} 0.32
-zhmc_adapter_usage_ratio{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05"} 0.0
-zhmc_adapter_usage_ratio{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05"} 0.0
+zhmc_adapter_usage_ratio{adapter="OSM1",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+zhmc_adapter_usage_ratio{adapter="FCP_120_SAN1_02",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.27
+zhmc_adapter_usage_ratio{adapter="FCP_104_SAN1_01",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.01
+zhmc_adapter_usage_ratio{adapter="OSM_12C_PSCN2_08",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+zhmc_adapter_usage_ratio{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+zhmc_adapter_usage_ratio{adapter="EP11_13C",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+zhmc_adapter_usage_ratio{adapter="FCP_121_SAN2_02",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.01
+zhmc_adapter_usage_ratio{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+zhmc_adapter_usage_ratio{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+zhmc_adapter_usage_ratio{adapter="FCP1.D1",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.3
+zhmc_adapter_usage_ratio{adapter="CRYP00",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+zhmc_adapter_usage_ratio{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+zhmc_adapter_usage_ratio{adapter="EP11_138",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+zhmc_adapter_usage_ratio{adapter="FCP_124_SAN1_03",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.27
+zhmc_adapter_usage_ratio{adapter="FCP_101_SAN2_00",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.27
+zhmc_adapter_usage_ratio{adapter="FCP_105_SAN2_01",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.27
+zhmc_adapter_usage_ratio{adapter="EP11_11C",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+zhmc_adapter_usage_ratio{adapter="FCP_125_SAN2_03",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.3
+zhmc_adapter_usage_ratio{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+zhmc_adapter_usage_ratio{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
 # HELP zhmc_processor_usage_ratio Usage ratio of the processor
 # TYPE zhmc_processor_usage_ratio gauge
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL000",type="ifl"} 0.03
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL004",type="ifl"} 0.05
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL008",type="ifl"} 0.02
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL00C",type="ifl"} 0.02
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL010",type="ifl"} 0.02
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL014",type="ifl"} 0.04
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL018",type="ifl"} 0.02
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL01C",type="ifl"} 0.03
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL020",type="ifl"} 0.02
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL024",type="ifl"} 0.01
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL028",type="ifl"} 0.01
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL02C",type="ifl"} 0.02
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL030",type="ifl"} 0.0
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL034",type="ifl"} 0.0
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL038",type="ifl"} 0.0
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL03C",type="ifl"} 0.01
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFP040",type="ifp"} 0.03
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL044",type="ifl"} 0.53
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL048",type="ifl"} 0.57
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL04C",type="ifl"} 0.63
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL050",type="ifl"} 0.6
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL054",type="ifl"} 0.6
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL058",type="ifl"} 0.66
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL05C",type="ifl"} 0.67
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL060",type="ifl"} 0.04
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL064",type="ifl"} 0.02
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL068",type="ifl"} 0.02
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL06C",type="ifl"} 0.02
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL070",type="ifl"} 0.02
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL078",type="ifl"} 0.02
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL07C",type="ifl"} 0.02
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="SAP00",type="sap"} 0.01
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="SAP01",type="sap"} 0.01
-zhmc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="SAP02",type="sap"} 0.01
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL000",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL004",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL008",type="ifl"} 0.01
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL00C",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL010",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL014",type="ifl"} 0.01
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL018",type="ifl"} 0.01
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL01C",type="ifl"} 0.01
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL020",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL024",type="ifl"} 0.55
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL028",type="ifl"} 0.54
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL02C",type="ifl"} 0.56
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL030",type="ifl"} 0.57
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL034",type="ifl"} 0.54
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL038",type="ifl"} 0.62
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL03C",type="ifl"} 0.58
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFP040",type="ifp"} 0.06
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL044",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL048",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL04C",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL050",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL054",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL058",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL05C",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL060",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL064",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL068",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL06C",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL070",type="ifl"} 0.01
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL078",type="ifl"} 0.01
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL07C",type="ifl"} 0.02
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="SAP00",type="sap"} 0.01
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="SAP01",type="sap"} 0.01
+zhmc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="SAP02",type="sap"} 0.01
 # HELP zhmc_processor_smt_mode_percent Percentage of time the processor was in SMT mode - -1 if not supported
 # TYPE zhmc_processor_smt_mode_percent gauge
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL000",type="ifl"} 5.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL004",type="ifl"} 7.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL008",type="ifl"} 2.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL00C",type="ifl"} 2.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL010",type="ifl"} 3.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL014",type="ifl"} 7.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL018",type="ifl"} 2.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL01C",type="ifl"} 3.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL020",type="ifl"} 2.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL024",type="ifl"} 1.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL028",type="ifl"} 1.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL02C",type="ifl"} 1.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL030",type="ifl"} 1.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL034",type="ifl"} 0.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL038",type="ifl"} 1.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL03C",type="ifl"} 1.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFP040",type="ifp"} 0.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL044",type="ifl"} 65.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL048",type="ifl"} 71.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL04C",type="ifl"} 76.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL050",type="ifl"} 74.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL054",type="ifl"} 73.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL058",type="ifl"} 80.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL05C",type="ifl"} 81.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL060",type="ifl"} 4.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL064",type="ifl"} 1.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL068",type="ifl"} 1.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL06C",type="ifl"} 1.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL070",type="ifl"} 1.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL078",type="ifl"} 1.0
-zhmc_processor_smt_mode_percent{cpc="CPCA",pod="wdc04-05",processor="IFL07C",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL000",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL004",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL008",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL00C",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL010",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL014",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL018",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL01C",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL020",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL024",type="ifl"} 68.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL028",type="ifl"} 67.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL02C",type="ifl"} 69.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL030",type="ifl"} 70.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL034",type="ifl"} 67.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL038",type="ifl"} 76.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL03C",type="ifl"} 71.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFP040",type="ifp"} 0.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL044",type="ifl"} 3.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL048",type="ifl"} 2.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL04C",type="ifl"} 2.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL050",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL054",type="ifl"} 3.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL058",type="ifl"} 2.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL05C",type="ifl"} 2.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL060",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL064",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL068",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL06C",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL070",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL078",type="ifl"} 1.0
+zhmc_processor_smt_mode_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL07C",type="ifl"} 1.0
 # HELP zhmc_processor_smt_thread0_usage_ratio Usage ratio of thread 0 of the processor when in SMT mode - -1 if not supported
 # TYPE zhmc_processor_smt_thread0_usage_ratio gauge
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL000",type="ifl"} 0.04
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL004",type="ifl"} 0.06
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL008",type="ifl"} 0.02
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL00C",type="ifl"} 0.02
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL010",type="ifl"} 0.02
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL014",type="ifl"} 0.01
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL018",type="ifl"} 0.02
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL01C",type="ifl"} 0.03
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL020",type="ifl"} 0.02
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL024",type="ifl"} 0.01
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL028",type="ifl"} 0.01
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL02C",type="ifl"} 0.01
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL030",type="ifl"} 0.01
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL034",type="ifl"} 0.01
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL038",type="ifl"} 0.01
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL03C",type="ifl"} 0.01
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFP040",type="ifp"} 0.03
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL044",type="ifl"} 0.55
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL048",type="ifl"} 0.59
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL04C",type="ifl"} 0.64
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL050",type="ifl"} 0.61
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL054",type="ifl"} 0.61
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL058",type="ifl"} 0.67
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL05C",type="ifl"} 0.69
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL060",type="ifl"} 0.04
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL064",type="ifl"} 0.02
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL068",type="ifl"} 0.01
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL06C",type="ifl"} 0.01
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL070",type="ifl"} 0.01
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL078",type="ifl"} 0.01
-zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL07C",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL000",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL004",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL008",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL00C",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL010",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL014",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL018",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL01C",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL020",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL024",type="ifl"} 0.56
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL028",type="ifl"} 0.55
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL02C",type="ifl"} 0.57
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL030",type="ifl"} 0.58
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL034",type="ifl"} 0.55
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL038",type="ifl"} 0.63
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL03C",type="ifl"} 0.59
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFP040",type="ifp"} 0.06
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL044",type="ifl"} 0.03
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL048",type="ifl"} 0.02
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL04C",type="ifl"} 0.02
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL050",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL054",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL058",type="ifl"} 0.02
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL05C",type="ifl"} 0.02
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL060",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL064",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL068",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL06C",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL070",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL078",type="ifl"} 0.01
+zhmc_processor_smt_thread0_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL07C",type="ifl"} 0.01
 # HELP zhmc_processor_smt_thread1_usage_ratio Usage ratio of thread 1 of the processor when in SMT mode - -1 if not supported
 # TYPE zhmc_processor_smt_thread1_usage_ratio gauge
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL000",type="ifl"} 0.02
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL004",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL008",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL00C",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL010",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL014",type="ifl"} 0.06
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL018",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL01C",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL020",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL024",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL028",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL02C",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL030",type="ifl"} 0.0
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL034",type="ifl"} 0.0
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL038",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL03C",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFP040",type="ifp"} 0.0
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL044",type="ifl"} 0.51
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL048",type="ifl"} 0.56
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL04C",type="ifl"} 0.62
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL050",type="ifl"} 0.6
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL054",type="ifl"} 0.6
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL058",type="ifl"} 0.65
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL05C",type="ifl"} 0.66
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL060",type="ifl"} 0.02
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL064",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL068",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL06C",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL070",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL078",type="ifl"} 0.01
-zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",pod="wdc04-05",processor="IFL07C",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL000",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL004",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL008",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL00C",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL010",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL014",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL018",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL01C",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL020",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL024",type="ifl"} 0.54
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL028",type="ifl"} 0.53
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL02C",type="ifl"} 0.56
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL030",type="ifl"} 0.56
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL034",type="ifl"} 0.53
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL038",type="ifl"} 0.61
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL03C",type="ifl"} 0.58
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFP040",type="ifp"} 0.0
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL044",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL048",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL04C",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL050",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL054",type="ifl"} 0.02
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL058",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL05C",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL060",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL064",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL068",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL06C",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL070",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL078",type="ifl"} 0.01
+zhmc_processor_smt_thread1_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05",processor="IFL07C",type="ifl"} 0.01
 # HELP zhmc_partition_processor_usage_ratio Usage ratio across all processors of the partition
 # TYPE zhmc_partition_processor_usage_ratio gauge
-zhmc_partition_processor_usage_ratio{cpc="CPCA",partition="MIKETEST",pod="wdc04-05"} 0.0
-zhmc_partition_processor_usage_ratio{cpc="CPCA",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_partition_processor_usage_ratio{cpc="CPCA",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_partition_processor_usage_ratio{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 0.01
+zhmc_partition_processor_usage_ratio{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_partition_processor_usage_ratio{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 0.0
 # HELP zhmc_partition_network_adapter_usage_ratio Usage ratio of all network adapters of the partition
 # TYPE zhmc_partition_network_adapter_usage_ratio gauge
-zhmc_partition_network_adapter_usage_ratio{cpc="CPCA",partition="MIKETEST",pod="wdc04-05"} 0.0
-zhmc_partition_network_adapter_usage_ratio{cpc="CPCA",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_partition_network_adapter_usage_ratio{cpc="CPCA",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_partition_network_adapter_usage_ratio{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_partition_network_adapter_usage_ratio{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_partition_network_adapter_usage_ratio{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 0.0
 # HELP zhmc_partition_storage_adapter_usage_ratio Usage ratio of all storage adapters of the partition
 # TYPE zhmc_partition_storage_adapter_usage_ratio gauge
-zhmc_partition_storage_adapter_usage_ratio{cpc="CPCA",partition="MIKETEST",pod="wdc04-05"} 0.2
-zhmc_partition_storage_adapter_usage_ratio{cpc="CPCA",partition="WILLVLAN2",pod="wdc04-05"} 0.19
-zhmc_partition_storage_adapter_usage_ratio{cpc="CPCA",partition="PENNY",pod="wdc04-05"} 0.2
+zhmc_partition_storage_adapter_usage_ratio{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 0.19
+zhmc_partition_storage_adapter_usage_ratio{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 0.18
+zhmc_partition_storage_adapter_usage_ratio{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 0.19
 # HELP zhmc_partition_accelerator_adapter_usage_ratio Usage ratio of all accelerator adapters of the partition
 # TYPE zhmc_partition_accelerator_adapter_usage_ratio gauge
-zhmc_partition_accelerator_adapter_usage_ratio{cpc="CPCA",partition="MIKETEST",pod="wdc04-05"} 0.0
-zhmc_partition_accelerator_adapter_usage_ratio{cpc="CPCA",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_partition_accelerator_adapter_usage_ratio{cpc="CPCA",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_partition_accelerator_adapter_usage_ratio{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_partition_accelerator_adapter_usage_ratio{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_partition_accelerator_adapter_usage_ratio{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 0.0
 # HELP zhmc_partition_crypto_adapter_usage_ratio Usage ratio of all crypto adapters of the partition
 # TYPE zhmc_partition_crypto_adapter_usage_ratio gauge
-zhmc_partition_crypto_adapter_usage_ratio{cpc="CPCA",partition="MIKETEST",pod="wdc04-05"} 0.0
-zhmc_partition_crypto_adapter_usage_ratio{cpc="CPCA",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_partition_crypto_adapter_usage_ratio{cpc="CPCA",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_partition_crypto_adapter_usage_ratio{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_partition_crypto_adapter_usage_ratio{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_partition_crypto_adapter_usage_ratio{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 0.0
 # HELP zhmc_cpc_processor_usage_ratio Usage ratio across all processors of the CPC
 # TYPE zhmc_cpc_processor_usage_ratio gauge
-zhmc_cpc_processor_usage_ratio{cpc="CPCA",pod="wdc04-05"} 0.16
+zhmc_cpc_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.14
 # HELP zhmc_cpc_network_adapter_usage_ratio Usage ratio across all network adapters of the CPC
 # TYPE zhmc_cpc_network_adapter_usage_ratio gauge
-zhmc_cpc_network_adapter_usage_ratio{cpc="CPCA",pod="wdc04-05"} 0.0
+zhmc_cpc_network_adapter_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
 # HELP zhmc_cpc_storage_adapter_usage_ratio Usage ratio across all storage adapters of the CPC
 # TYPE zhmc_cpc_storage_adapter_usage_ratio gauge
-zhmc_cpc_storage_adapter_usage_ratio{cpc="CPCA",pod="wdc04-05"} 0.22
+zhmc_cpc_storage_adapter_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.21
 # HELP zhmc_cpc_accelerator_adapter_usage_ratio Usage ratio across all accelerator adapters of the CPC
 # TYPE zhmc_cpc_accelerator_adapter_usage_ratio gauge
-zhmc_cpc_accelerator_adapter_usage_ratio{cpc="CPCA",pod="wdc04-05"} 0.0
+zhmc_cpc_accelerator_adapter_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
 # HELP zhmc_cpc_crypto_adapter_usage_ratio Usage ratio across all crypto adapters of the CPC
 # TYPE zhmc_cpc_crypto_adapter_usage_ratio gauge
-zhmc_cpc_crypto_adapter_usage_ratio{cpc="CPCA",pod="wdc04-05"} 0.0
+zhmc_cpc_crypto_adapter_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
 # HELP zhmc_cpc_power_watts Power consumption of the CPC
 # TYPE zhmc_cpc_power_watts gauge
-zhmc_cpc_power_watts{cpc="CPCA",pod="wdc04-05"} 2283.0
+zhmc_cpc_power_watts{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 2279.0
 # HELP zhmc_cpc_ambient_temperature_celsius Ambient temperature of the CPC
 # TYPE zhmc_cpc_ambient_temperature_celsius gauge
-zhmc_cpc_ambient_temperature_celsius{cpc="CPCA",pod="wdc04-05"} 25.7
+zhmc_cpc_ambient_temperature_celsius{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 25.2
 # HELP zhmc_cpc_ifl_shared_processor_usage_ratio Usage ratio across all shared IFL processors of the CPC
 # TYPE zhmc_cpc_ifl_shared_processor_usage_ratio gauge
-zhmc_cpc_ifl_shared_processor_usage_ratio{cpc="CPCA",pod="wdc04-05"} 0.16
+zhmc_cpc_ifl_shared_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.14
 # HELP zhmc_cpc_ifl_processor_usage_ratio Usage ratio across all IFL processors of the CPC
 # TYPE zhmc_cpc_ifl_processor_usage_ratio gauge
-zhmc_cpc_ifl_processor_usage_ratio{cpc="CPCA",pod="wdc04-05"} 0.16
+zhmc_cpc_ifl_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.14
 # HELP zhmc_cpc_shared_processor_usage_ratio Usage ratio across all shared processors of the CPC
 # TYPE zhmc_cpc_shared_processor_usage_ratio gauge
-zhmc_cpc_shared_processor_usage_ratio{cpc="CPCA",pod="wdc04-05"} 0.15
+zhmc_cpc_shared_processor_usage_ratio{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.14
 # HELP zhmc_cpc_humidity_percent Relative humidity
 # TYPE zhmc_cpc_humidity_percent gauge
-zhmc_cpc_humidity_percent{cpc="CPCA",pod="wdc04-05"} 33.0
+zhmc_cpc_humidity_percent{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 39.0
 # HELP zhmc_cpc_dew_point_celsius Dew point
 # TYPE zhmc_cpc_dew_point_celsius gauge
-zhmc_cpc_dew_point_celsius{cpc="CPCA",pod="wdc04-05"} 8.0
+zhmc_cpc_dew_point_celsius{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 10.2
 # HELP zhmc_cpc_heat_load_total_btu_per_hour Total heat load of the CPC
 # TYPE zhmc_cpc_heat_load_total_btu_per_hour gauge
-zhmc_cpc_heat_load_total_btu_per_hour{cpc="CPCA",pod="wdc04-05"} 7795.0
+zhmc_cpc_heat_load_total_btu_per_hour{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 7781.0
 # HELP zhmc_cpc_heat_load_forced_air_btu_per_hour Heat load of the CPC covered by forced-air
 # TYPE zhmc_cpc_heat_load_forced_air_btu_per_hour gauge
-zhmc_cpc_heat_load_forced_air_btu_per_hour{cpc="CPCA",pod="wdc04-05"} 7795.0
+zhmc_cpc_heat_load_forced_air_btu_per_hour{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 7781.0
 # HELP zhmc_cpc_heat_load_water_btu_per_hour Heat load of the CPC covered by water
 # TYPE zhmc_cpc_heat_load_water_btu_per_hour gauge
-zhmc_cpc_heat_load_water_btu_per_hour{cpc="CPCA",pod="wdc04-05"} 0.0
+zhmc_cpc_heat_load_water_btu_per_hour{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
 # HELP zhmc_cpc_exhaust_temperature_celsius Exhaust temperature of the CPC
 # TYPE zhmc_cpc_exhaust_temperature_celsius gauge
-zhmc_cpc_exhaust_temperature_celsius{cpc="CPCA",pod="wdc04-05"} 33.0
+zhmc_cpc_exhaust_temperature_celsius{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 32.0
 # HELP zhmc_nic_bytes_sent_count Number of Bytes in unicast packets that were sent
 # TYPE zhmc_nic_bytes_sent_count gauge
-zhmc_nic_bytes_sent_count{cpc="CPCA",,nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_bytes_sent_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 6.0
-zhmc_nic_bytes_sent_count{cpc="CPCA",,nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_bytes_sent_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 90.0
-zhmc_nic_bytes_sent_count{cpc="CPCA",,nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_bytes_sent_count{cpc="CPCA",,nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
-zhmc_nic_bytes_sent_count{cpc="CPCA",,nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_bytes_sent_count{cpc="CPCA",,nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_bytes_sent_count{cpc="CPCA",,nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_bytes_sent_count{cpc="CPCA",mzr="US-East",nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_bytes_sent_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 6.0
+zhmc_nic_bytes_sent_count{cpc="CPCA",mzr="US-East",nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_bytes_sent_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 28.0
+zhmc_nic_bytes_sent_count{cpc="CPCA",mzr="US-East",nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_bytes_sent_count{cpc="CPCA",mzr="US-East",nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_nic_bytes_sent_count{cpc="CPCA",mzr="US-East",nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_bytes_sent_count{cpc="CPCA",mzr="US-East",nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_bytes_sent_count{cpc="CPCA",mzr="US-East",nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
 # HELP zhmc_nic_bytes_received_count Number of Bytes in unicast packets that were received
 # TYPE zhmc_nic_bytes_received_count gauge
-zhmc_nic_bytes_received_count{cpc="CPCA",,nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_bytes_received_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 2.0
-zhmc_nic_bytes_received_count{cpc="CPCA",,nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_bytes_received_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 64.0
-zhmc_nic_bytes_received_count{cpc="CPCA",,nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_bytes_received_count{cpc="CPCA",,nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
-zhmc_nic_bytes_received_count{cpc="CPCA",,nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_bytes_received_count{cpc="CPCA",,nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_bytes_received_count{cpc="CPCA",,nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_bytes_received_count{cpc="CPCA",mzr="US-East",nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_bytes_received_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 2.0
+zhmc_nic_bytes_received_count{cpc="CPCA",mzr="US-East",nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_bytes_received_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 15.0
+zhmc_nic_bytes_received_count{cpc="CPCA",mzr="US-East",nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_bytes_received_count{cpc="CPCA",mzr="US-East",nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_nic_bytes_received_count{cpc="CPCA",mzr="US-East",nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_bytes_received_count{cpc="CPCA",mzr="US-East",nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_bytes_received_count{cpc="CPCA",mzr="US-East",nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
 # HELP zhmc_nic_packets_sent_count Number of unicast packets that were sent
 # TYPE zhmc_nic_packets_sent_count gauge
-zhmc_nic_packets_sent_count{cpc="CPCA",,nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 2266.0
-zhmc_nic_packets_sent_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 40.0
-zhmc_nic_packets_sent_count{cpc="CPCA",,nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 3.0
-zhmc_nic_packets_sent_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 915.0
-zhmc_nic_packets_sent_count{cpc="CPCA",,nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_count{cpc="CPCA",,nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 14558.0
-zhmc_nic_packets_sent_count{cpc="CPCA",,nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 3.0
-zhmc_nic_packets_sent_count{cpc="CPCA",,nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 2.0
-zhmc_nic_packets_sent_count{cpc="CPCA",,nic="HMGR0",partition="PENNY",pod="wdc04-05"} 123.0
+zhmc_nic_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 4113.0
+zhmc_nic_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 49.0
+zhmc_nic_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 2.0
+zhmc_nic_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 218.0
+zhmc_nic_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_count{cpc="CPCA",mzr="US-East",nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 36076.0
+zhmc_nic_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 3.0
+zhmc_nic_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 2.0
+zhmc_nic_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMGR0",partition="PENNY",pod="wdc04-05"} 4099.0
 # HELP zhmc_nic_packets_received_count Number of unicast packets that were received
 # TYPE zhmc_nic_packets_received_count gauge
-zhmc_nic_packets_received_count{cpc="CPCA",,nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 8723.0
-zhmc_nic_packets_received_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 36.0
-zhmc_nic_packets_received_count{cpc="CPCA",,nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 7067.0
-zhmc_nic_packets_received_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 1186.0
-zhmc_nic_packets_received_count{cpc="CPCA",,nic="HMGR1",partition="PENNY",pod="wdc04-05"} 45110.0
-zhmc_nic_packets_received_count{cpc="CPCA",,nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 206483.0
-zhmc_nic_packets_received_count{cpc="CPCA",,nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 7067.0
-zhmc_nic_packets_received_count{cpc="CPCA",,nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 7067.0
-zhmc_nic_packets_received_count{cpc="CPCA",,nic="HMGR0",partition="PENNY",pod="wdc04-05"} 45202.0
+zhmc_nic_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 4127.0
+zhmc_nic_packets_received_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 67.0
+zhmc_nic_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 1121.0
+zhmc_nic_packets_received_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 342.0
+zhmc_nic_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMGR1",partition="PENNY",pod="wdc04-05"} 2.198806e+06
+zhmc_nic_packets_received_count{cpc="CPCA",mzr="US-East",nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 453496.0
+zhmc_nic_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 1121.0
+zhmc_nic_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 1121.0
+zhmc_nic_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMGR0",partition="PENNY",pod="wdc04-05"} 2.20192e+06
 # HELP zhmc_nic_packets_sent_dropped_count Number of sent packets that were dropped (resource shortage)
 # TYPE zhmc_nic_packets_sent_dropped_count gauge
-zhmc_nic_packets_sent_dropped_count{cpc="CPCA",,nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_dropped_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_dropped_count{cpc="CPCA",,nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_dropped_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_dropped_count{cpc="CPCA",,nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_dropped_count{cpc="CPCA",,nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_dropped_count{cpc="CPCA",,nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_dropped_count{cpc="CPCA",,nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_dropped_count{cpc="CPCA",,nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_dropped_count{cpc="CPCA",mzr="US-East",nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_dropped_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_dropped_count{cpc="CPCA",mzr="US-East",nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_dropped_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_dropped_count{cpc="CPCA",mzr="US-East",nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_dropped_count{cpc="CPCA",mzr="US-East",nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_dropped_count{cpc="CPCA",mzr="US-East",nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_dropped_count{cpc="CPCA",mzr="US-East",nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_dropped_count{cpc="CPCA",mzr="US-East",nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
 # HELP zhmc_nic_packets_received_dropped_count Number of received packets that were dropped (resource shortage)
 # TYPE zhmc_nic_packets_received_dropped_count gauge
-zhmc_nic_packets_received_dropped_count{cpc="CPCA",,nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_received_dropped_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_packets_received_dropped_count{cpc="CPCA",,nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_received_dropped_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_received_dropped_count{cpc="CPCA",,nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_packets_received_dropped_count{cpc="CPCA",,nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
-zhmc_nic_packets_received_dropped_count{cpc="CPCA",,nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_received_dropped_count{cpc="CPCA",,nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_received_dropped_count{cpc="CPCA",,nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_dropped_count{cpc="CPCA",mzr="US-East",nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_dropped_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_dropped_count{cpc="CPCA",mzr="US-East",nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_dropped_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_dropped_count{cpc="CPCA",mzr="US-East",nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_dropped_count{cpc="CPCA",mzr="US-East",nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_dropped_count{cpc="CPCA",mzr="US-East",nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_dropped_count{cpc="CPCA",mzr="US-East",nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_dropped_count{cpc="CPCA",mzr="US-East",nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
 # HELP zhmc_nic_packets_sent_discarded_count Number of sent packets that were discarded (malformed)
 # TYPE zhmc_nic_packets_sent_discarded_count gauge
-zhmc_nic_packets_sent_discarded_count{cpc="CPCA",,nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_discarded_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_discarded_count{cpc="CPCA",,nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_discarded_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_discarded_count{cpc="CPCA",,nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_discarded_count{cpc="CPCA",,nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_discarded_count{cpc="CPCA",,nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_discarded_count{cpc="CPCA",,nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_sent_discarded_count{cpc="CPCA",,nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_discarded_count{cpc="CPCA",mzr="US-East",nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_discarded_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_discarded_count{cpc="CPCA",mzr="US-East",nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_discarded_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_discarded_count{cpc="CPCA",mzr="US-East",nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_discarded_count{cpc="CPCA",mzr="US-East",nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 8.0
+zhmc_nic_packets_sent_discarded_count{cpc="CPCA",mzr="US-East",nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_discarded_count{cpc="CPCA",mzr="US-East",nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_sent_discarded_count{cpc="CPCA",mzr="US-East",nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
 # HELP zhmc_nic_packets_received_discarded_count Number of received packets that were discarded (malformed)
 # TYPE zhmc_nic_packets_received_discarded_count gauge
-zhmc_nic_packets_received_discarded_count{cpc="CPCA",,nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_received_discarded_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_packets_received_discarded_count{cpc="CPCA",,nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_received_discarded_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_received_discarded_count{cpc="CPCA",,nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_packets_received_discarded_count{cpc="CPCA",,nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
-zhmc_nic_packets_received_discarded_count{cpc="CPCA",,nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_received_discarded_count{cpc="CPCA",,nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_packets_received_discarded_count{cpc="CPCA",,nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_discarded_count{cpc="CPCA",mzr="US-East",nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_discarded_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_discarded_count{cpc="CPCA",mzr="US-East",nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_discarded_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_discarded_count{cpc="CPCA",mzr="US-East",nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_discarded_count{cpc="CPCA",mzr="US-East",nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 10.0
+zhmc_nic_packets_received_discarded_count{cpc="CPCA",mzr="US-East",nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_discarded_count{cpc="CPCA",mzr="US-East",nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_packets_received_discarded_count{cpc="CPCA",mzr="US-East",nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
 # HELP zhmc_nic_multicast_packets_sent_count Number of multicast packets sent
 # TYPE zhmc_nic_multicast_packets_sent_count gauge
-zhmc_nic_multicast_packets_sent_count{cpc="CPCA",,nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 7.0
-zhmc_nic_multicast_packets_sent_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 2.0
-zhmc_nic_multicast_packets_sent_count{cpc="CPCA",,nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 2.0
-zhmc_nic_multicast_packets_sent_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 3.0
-zhmc_nic_multicast_packets_sent_count{cpc="CPCA",,nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_multicast_packets_sent_count{cpc="CPCA",,nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 2.0
-zhmc_nic_multicast_packets_sent_count{cpc="CPCA",,nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 2.0
-zhmc_nic_multicast_packets_sent_count{cpc="CPCA",,nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 1.0
-zhmc_nic_multicast_packets_sent_count{cpc="CPCA",,nic="HMGR0",partition="PENNY",pod="wdc04-05"} 2.0
+zhmc_nic_multicast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 4.0
+zhmc_nic_multicast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 2.0
+zhmc_nic_multicast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 1.0
+zhmc_nic_multicast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 2.0
+zhmc_nic_multicast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_multicast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 2.0
+zhmc_nic_multicast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 2.0
+zhmc_nic_multicast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 1.0
+zhmc_nic_multicast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMGR0",partition="PENNY",pod="wdc04-05"} 2.0
 # HELP zhmc_nic_multicast_packets_received_count Number of multicast packets received
 # TYPE zhmc_nic_multicast_packets_received_count gauge
-zhmc_nic_multicast_packets_received_count{cpc="CPCA",,nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_multicast_packets_received_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_multicast_packets_received_count{cpc="CPCA",,nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_multicast_packets_received_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_multicast_packets_received_count{cpc="CPCA",,nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_multicast_packets_received_count{cpc="CPCA",,nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
-zhmc_nic_multicast_packets_received_count{cpc="CPCA",,nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_multicast_packets_received_count{cpc="CPCA",,nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_multicast_packets_received_count{cpc="CPCA",,nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_multicast_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_multicast_packets_received_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_multicast_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_multicast_packets_received_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_multicast_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_multicast_packets_received_count{cpc="CPCA",mzr="US-East",nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 6.0
+zhmc_nic_multicast_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_multicast_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_multicast_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
 # HELP zhmc_nic_broadcast_packets_sent_count Number of broadcast packets sent
 # TYPE zhmc_nic_broadcast_packets_sent_count gauge
-zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",,nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 1.0
-zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",,nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 1.0
-zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 1.0
-zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",,nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",,nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
-zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",,nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 1.0
-zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",,nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 1.0
-zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",,nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 1.0
+zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 1.0
+zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 1.0
+zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 1.0
+zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 1.0
+zhmc_nic_broadcast_packets_sent_count{cpc="CPCA",mzr="US-East",nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
 # HELP zhmc_nic_broadcast_packets_received_count Number of broadcast packets received
 # TYPE zhmc_nic_broadcast_packets_received_count gauge
-zhmc_nic_broadcast_packets_received_count{cpc="CPCA",,nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 7064.0
-zhmc_nic_broadcast_packets_received_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_broadcast_packets_received_count{cpc="CPCA",,nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 7067.0
-zhmc_nic_broadcast_packets_received_count{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 256.0
-zhmc_nic_broadcast_packets_received_count{cpc="CPCA",,nic="HMGR1",partition="PENNY",pod="wdc04-05"} 45107.0
-zhmc_nic_broadcast_packets_received_count{cpc="CPCA",,nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 205819.0
-zhmc_nic_broadcast_packets_received_count{cpc="CPCA",,nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 7067.0
-zhmc_nic_broadcast_packets_received_count{cpc="CPCA",,nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 7067.0
-zhmc_nic_broadcast_packets_received_count{cpc="CPCA",,nic="HMGR0",partition="PENNY",pod="wdc04-05"} 45103.0
+zhmc_nic_broadcast_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 1117.0
+zhmc_nic_broadcast_packets_received_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 31.0
+zhmc_nic_broadcast_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 1121.0
+zhmc_nic_broadcast_packets_received_count{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 161.0
+zhmc_nic_broadcast_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMGR1",partition="PENNY",pod="wdc04-05"} 2.198864e+06
+zhmc_nic_broadcast_packets_received_count{cpc="CPCA",mzr="US-East",nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 452826.0
+zhmc_nic_broadcast_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 1121.0
+zhmc_nic_broadcast_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 1121.0
+zhmc_nic_broadcast_packets_received_count{cpc="CPCA",mzr="US-East",nic="HMGR0",partition="PENNY",pod="wdc04-05"} 2.19889e+06
 # HELP zhmc_nic_data_sent_bytes Amount of data sent over the collection interval
 # TYPE zhmc_nic_data_sent_bytes gauge
-zhmc_nic_data_sent_bytes{cpc="CPCA",,nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_sent_bytes{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_data_sent_bytes{cpc="CPCA",,nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_sent_bytes{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_sent_bytes{cpc="CPCA",,nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_data_sent_bytes{cpc="CPCA",,nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
-zhmc_nic_data_sent_bytes{cpc="CPCA",,nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_sent_bytes{cpc="CPCA",,nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_sent_bytes{cpc="CPCA",,nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_data_sent_bytes{cpc="CPCA",mzr="US-East",nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_sent_bytes{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_data_sent_bytes{cpc="CPCA",mzr="US-East",nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_sent_bytes{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_sent_bytes{cpc="CPCA",mzr="US-East",nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_data_sent_bytes{cpc="CPCA",mzr="US-East",nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_nic_data_sent_bytes{cpc="CPCA",mzr="US-East",nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_sent_bytes{cpc="CPCA",mzr="US-East",nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_sent_bytes{cpc="CPCA",mzr="US-East",nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
 # HELP zhmc_nic_data_received_bytes Amount of data received over the collection interval
 # TYPE zhmc_nic_data_received_bytes gauge
-zhmc_nic_data_received_bytes{cpc="CPCA",,nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_received_bytes{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_data_received_bytes{cpc="CPCA",,nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_received_bytes{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_received_bytes{cpc="CPCA",,nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_data_received_bytes{cpc="CPCA",,nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
-zhmc_nic_data_received_bytes{cpc="CPCA",,nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_received_bytes{cpc="CPCA",,nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_received_bytes{cpc="CPCA",,nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_data_received_bytes{cpc="CPCA",mzr="US-East",nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_received_bytes{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_data_received_bytes{cpc="CPCA",mzr="US-East",nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_received_bytes{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_received_bytes{cpc="CPCA",mzr="US-East",nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_data_received_bytes{cpc="CPCA",mzr="US-East",nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_nic_data_received_bytes{cpc="CPCA",mzr="US-East",nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_received_bytes{cpc="CPCA",mzr="US-East",nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_received_bytes{cpc="CPCA",mzr="US-East",nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
 # HELP zhmc_nic_data_rate_sent_bytes_per_second Data rate sent over the collection interval
 # TYPE zhmc_nic_data_rate_sent_bytes_per_second gauge
-zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",,nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",,nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",,nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",,nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
-zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",,nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",,nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",,nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",mzr="US-East",nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",mzr="US-East",nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",mzr="US-East",nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",mzr="US-East",nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",mzr="US-East",nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",mzr="US-East",nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_sent_bytes_per_second{cpc="CPCA",mzr="US-East",nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
 # HELP zhmc_nic_data_rate_received_bytes_per_second Data rate received over the collection interval
 # TYPE zhmc_nic_data_rate_received_bytes_per_second gauge
-zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",,nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",,nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",,nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",,nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
-zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",,nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
-zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",,nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",,nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
-zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",,nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",mzr="US-East",nic="HMVST40001",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",mzr="US-East",nic="HMVST40003",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",mzr="US-East",nic="HAMGMT0_ssc_mgmt",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",mzr="US-East",nic="HMGR1",partition="PENNY",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",mzr="US-East",nic="IMGMT0_ssc_mgmt",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",mzr="US-East",nic="HMVST40002",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",mzr="US-East",nic="HMVST40000",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_nic_data_rate_received_bytes_per_second{cpc="CPCA",mzr="US-East",nic="HMGR0",partition="PENNY",pod="wdc04-05"} 0.0
 # HELP zhmc_port_bytes_sent_count Number of Bytes in unicast packets that were sent
 # TYPE zhmc_port_bytes_sent_count gauge
-zhmc_port_bytes_sent_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 1.240782214936e+012
-zhmc_port_bytes_sent_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 2.43372535e+011
-zhmc_port_bytes_sent_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_bytes_sent_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 6.409296795e+010
-zhmc_port_bytes_sent_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 2.32897467008e+011
-zhmc_port_bytes_sent_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_bytes_sent_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 3.33583573122e+011
-zhmc_port_bytes_sent_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 1.1833615823e+010
+zhmc_port_bytes_sent_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.507262554781e+012
+zhmc_port_bytes_sent_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 2.43835296642e+011
+zhmc_port_bytes_sent_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_bytes_sent_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 6.4139822089e+010
+zhmc_port_bytes_sent_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 2.43246035861e+011
+zhmc_port_bytes_sent_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_bytes_sent_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 6.07818967299e+011
+zhmc_port_bytes_sent_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.1881573114e+010
 # HELP zhmc_port_bytes_received_count Number of Bytes in unicast packets that were received
 # TYPE zhmc_port_bytes_received_count gauge
-zhmc_port_bytes_received_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 8.002363310859e+012
-zhmc_port_bytes_received_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 1.760614620079e+012
-zhmc_port_bytes_received_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_bytes_received_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 2.53465469657e+011
-zhmc_port_bytes_received_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 2.081002662651e+012
-zhmc_port_bytes_received_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_bytes_received_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 2.242590823667e+012
-zhmc_port_bytes_received_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 3.39407784517e+011
+zhmc_port_bytes_received_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.0792682943354e+013
+zhmc_port_bytes_received_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.767158928309e+012
+zhmc_port_bytes_received_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_bytes_received_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 2.53574001932e+011
+zhmc_port_bytes_received_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 2.248649421627e+012
+zhmc_port_bytes_received_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_bytes_received_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 4.987490770863e+012
+zhmc_port_bytes_received_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 3.39516874475e+011
 # HELP zhmc_port_packets_sent_count Number of unicast packets that were sent
 # TYPE zhmc_port_packets_sent_count gauge
-zhmc_port_packets_sent_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 1.999204377e+09
-zhmc_port_packets_sent_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 1.496309617e+09
-zhmc_port_packets_sent_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_packets_sent_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 7.7760612e+07
-zhmc_port_packets_sent_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 5.10267852e+08
-zhmc_port_packets_sent_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_packets_sent_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 5.52200345e+08
-zhmc_port_packets_sent_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 5.2491916e+07
+zhmc_port_packets_sent_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 2.55980834e+09
+zhmc_port_packets_sent_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.499304654e+09
+zhmc_port_packets_sent_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_packets_sent_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 7.8007212e+07
+zhmc_port_packets_sent_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 5.61008891e+08
+zhmc_port_packets_sent_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_packets_sent_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.21867209e+09
+zhmc_port_packets_sent_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 5.275366e+07
 # HELP zhmc_port_packets_received_count Number of unicast packets that were received
 # TYPE zhmc_port_packets_received_count gauge
-zhmc_port_packets_received_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 5.717682605e+09
-zhmc_port_packets_received_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 2.559610993e+09
-zhmc_port_packets_received_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_packets_received_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 2.74861936e+08
-zhmc_port_packets_received_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 1.832781011e+09
-zhmc_port_packets_received_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_packets_received_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 1.700386081e+09
-zhmc_port_packets_received_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 2.9080466e+08
+zhmc_port_packets_received_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 7.703941077e+09
+zhmc_port_packets_received_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 2.576730272e+09
+zhmc_port_packets_received_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_packets_received_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 2.75184789e+08
+zhmc_port_packets_received_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 2.017703606e+09
+zhmc_port_packets_received_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_packets_received_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 3.681868642e+09
+zhmc_port_packets_received_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 2.91129005e+08
 # HELP zhmc_port_packets_sent_dropped_count Number of sent packets that were dropped (resource shortage)
 # TYPE zhmc_port_packets_sent_dropped_count gauge
-zhmc_port_packets_sent_dropped_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_packets_sent_dropped_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_packets_sent_dropped_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_packets_sent_dropped_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_packets_sent_dropped_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_packets_sent_dropped_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_packets_sent_dropped_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_packets_sent_dropped_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
+zhmc_port_packets_sent_dropped_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_packets_sent_dropped_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_packets_sent_dropped_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_packets_sent_dropped_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_packets_sent_dropped_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_packets_sent_dropped_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_packets_sent_dropped_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_packets_sent_dropped_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
 # HELP zhmc_port_packets_received_dropped_count Number of received packets that were dropped (resource shortage)
 # TYPE zhmc_port_packets_received_dropped_count gauge
-zhmc_port_packets_received_dropped_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_packets_received_dropped_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 14.0
-zhmc_port_packets_received_dropped_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_packets_received_dropped_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 1.0
-zhmc_port_packets_received_dropped_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 52.0
-zhmc_port_packets_received_dropped_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_packets_received_dropped_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 10.0
-zhmc_port_packets_received_dropped_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 8.0
+zhmc_port_packets_received_dropped_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_packets_received_dropped_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 14.0
+zhmc_port_packets_received_dropped_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_packets_received_dropped_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.0
+zhmc_port_packets_received_dropped_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 52.0
+zhmc_port_packets_received_dropped_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_packets_received_dropped_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 10.0
+zhmc_port_packets_received_dropped_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 8.0
 # HELP zhmc_port_packets_sent_discarded_count Number of sent packets that were discarded (malformed)
 # TYPE zhmc_port_packets_sent_discarded_count gauge
-zhmc_port_packets_sent_discarded_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_packets_sent_discarded_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_packets_sent_discarded_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_packets_sent_discarded_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_packets_sent_discarded_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_packets_sent_discarded_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_packets_sent_discarded_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_packets_sent_discarded_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
+zhmc_port_packets_sent_discarded_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_packets_sent_discarded_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_packets_sent_discarded_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_packets_sent_discarded_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_packets_sent_discarded_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_packets_sent_discarded_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_packets_sent_discarded_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_packets_sent_discarded_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
 # HELP zhmc_port_packets_received_discarded_count Number of received packets that were discarded (malformed)
 # TYPE zhmc_port_packets_received_discarded_count gauge
-zhmc_port_packets_received_discarded_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 33.0
-zhmc_port_packets_received_discarded_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_packets_received_discarded_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_packets_received_discarded_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 264.0
-zhmc_port_packets_received_discarded_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_packets_received_discarded_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_packets_received_discarded_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 52.0
-zhmc_port_packets_received_discarded_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 60.0
+zhmc_port_packets_received_discarded_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 33.0
+zhmc_port_packets_received_discarded_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_packets_received_discarded_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_packets_received_discarded_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 264.0
+zhmc_port_packets_received_discarded_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_packets_received_discarded_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_packets_received_discarded_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 52.0
+zhmc_port_packets_received_discarded_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 60.0
 # HELP zhmc_port_multicast_packets_sent_count Number of multicast packets sent
 # TYPE zhmc_port_multicast_packets_sent_count gauge
-zhmc_port_multicast_packets_sent_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 1.977074e+06
-zhmc_port_multicast_packets_sent_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 1.700442e+06
-zhmc_port_multicast_packets_sent_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_multicast_packets_sent_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 1.699034e+06
-zhmc_port_multicast_packets_sent_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 1.671747e+06
-zhmc_port_multicast_packets_sent_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_multicast_packets_sent_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 1.715192e+06
-zhmc_port_multicast_packets_sent_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 1.713982e+06
+zhmc_port_multicast_packets_sent_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 2.22367e+06
+zhmc_port_multicast_packets_sent_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.948191e+06
+zhmc_port_multicast_packets_sent_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_multicast_packets_sent_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.945628e+06
+zhmc_port_multicast_packets_sent_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.91852e+06
+zhmc_port_multicast_packets_sent_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_multicast_packets_sent_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.961788e+06
+zhmc_port_multicast_packets_sent_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.960602e+06
 # HELP zhmc_port_multicast_packets_received_count Number of multicast packets received
 # TYPE zhmc_port_multicast_packets_received_count gauge
-zhmc_port_multicast_packets_received_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 1.814749e+06
-zhmc_port_multicast_packets_received_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 1.1942878e+07
-zhmc_port_multicast_packets_received_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_multicast_packets_received_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 2.351573e+06
-zhmc_port_multicast_packets_received_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 1.2104179e+07
-zhmc_port_multicast_packets_received_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_multicast_packets_received_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 2.350594e+06
-zhmc_port_multicast_packets_received_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 1.815062e+06
+zhmc_port_multicast_packets_received_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 2.085537e+06
+zhmc_port_multicast_packets_received_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.3716533e+07
+zhmc_port_multicast_packets_received_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_multicast_packets_received_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 2.622439e+06
+zhmc_port_multicast_packets_received_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.3878248e+07
+zhmc_port_multicast_packets_received_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_multicast_packets_received_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 2.621445e+06
+zhmc_port_multicast_packets_received_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 2.085871e+06
 # HELP zhmc_port_broadcast_packets_sent_count Number of broadcast packets sent
 # TYPE zhmc_port_broadcast_packets_sent_count gauge
-zhmc_port_broadcast_packets_sent_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 4.2808199e+07
-zhmc_port_broadcast_packets_sent_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 195430.0
-zhmc_port_broadcast_packets_sent_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_broadcast_packets_sent_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 300173.0
-zhmc_port_broadcast_packets_sent_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 37914.0
-zhmc_port_broadcast_packets_sent_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_broadcast_packets_sent_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 246233.0
-zhmc_port_broadcast_packets_sent_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 28762.0
+zhmc_port_broadcast_packets_sent_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 4.280821e+07
+zhmc_port_broadcast_packets_sent_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 201366.0
+zhmc_port_broadcast_packets_sent_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_broadcast_packets_sent_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 300179.0
+zhmc_port_broadcast_packets_sent_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 38731.0
+zhmc_port_broadcast_packets_sent_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_broadcast_packets_sent_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 246243.0
+zhmc_port_broadcast_packets_sent_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 28786.0
 # HELP zhmc_port_broadcast_packets_received_count Number of broadcast packets received
 # TYPE zhmc_port_broadcast_packets_received_count gauge
-zhmc_port_broadcast_packets_received_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 1.3441174e+07
-zhmc_port_broadcast_packets_received_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 1.07096521e+08
-zhmc_port_broadcast_packets_received_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_broadcast_packets_received_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 5.7094703e+07
-zhmc_port_broadcast_packets_received_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 1.04748363e+08
-zhmc_port_broadcast_packets_received_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_broadcast_packets_received_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 5.6871486e+07
-zhmc_port_broadcast_packets_received_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 5.5853886e+07
+zhmc_port_broadcast_packets_received_count{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.3470031e+07
+zhmc_port_broadcast_packets_received_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.15572536e+08
+zhmc_port_broadcast_packets_received_count{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_broadcast_packets_received_count{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 5.7123565e+07
+zhmc_port_broadcast_packets_received_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1.13229372e+08
+zhmc_port_broadcast_packets_received_count{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_broadcast_packets_received_count{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 5.6900344e+07
+zhmc_port_broadcast_packets_received_count{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 5.5882729e+07
 # HELP zhmc_port_data_sent_bytes Amount of data sent over the collection interval
 # TYPE zhmc_port_data_sent_bytes gauge
-zhmc_port_data_sent_bytes{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 60778.0
-zhmc_port_data_sent_bytes{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 382.0
-zhmc_port_data_sent_bytes{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_data_sent_bytes{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 190.0
-zhmc_port_data_sent_bytes{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 3340.0
-zhmc_port_data_sent_bytes{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_data_sent_bytes{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 41122.0
-zhmc_port_data_sent_bytes{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 380.0
+zhmc_port_data_sent_bytes{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1480.0
+zhmc_port_data_sent_bytes{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 190.0
+zhmc_port_data_sent_bytes{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_data_sent_bytes{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 380.0
+zhmc_port_data_sent_bytes{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 14278.0
+zhmc_port_data_sent_bytes{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_data_sent_bytes{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 710598.0
+zhmc_port_data_sent_bytes{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 190.0
 # HELP zhmc_port_data_received_bytes Amount of data received over the collection interval
 # TYPE zhmc_port_data_received_bytes gauge
-zhmc_port_data_received_bytes{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 22454.0
-zhmc_port_data_received_bytes{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 5023.0
-zhmc_port_data_received_bytes{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_data_received_bytes{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 766.0
-zhmc_port_data_received_bytes{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 20716.0
-zhmc_port_data_received_bytes{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_data_received_bytes{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 13951.0
-zhmc_port_data_received_bytes{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 383.0
+zhmc_port_data_received_bytes{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 2078.0
+zhmc_port_data_received_bytes{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 4471.0
+zhmc_port_data_received_bytes{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_data_received_bytes{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 447.0
+zhmc_port_data_received_bytes{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 30165.0
+zhmc_port_data_received_bytes{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_data_received_bytes{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 3.085951e+06
+zhmc_port_data_received_bytes{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 830.0
 # HELP zhmc_port_data_rate_sent_bytes_per_second Data rate sent over the collection interval
 # TYPE zhmc_port_data_rate_sent_bytes_per_second gauge
-zhmc_port_data_rate_sent_bytes_per_second{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 2025.0
-zhmc_port_data_rate_sent_bytes_per_second{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 12.0
-zhmc_port_data_rate_sent_bytes_per_second{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_data_rate_sent_bytes_per_second{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 6.0
-zhmc_port_data_rate_sent_bytes_per_second{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 111.0
-zhmc_port_data_rate_sent_bytes_per_second{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_data_rate_sent_bytes_per_second{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 1370.0
-zhmc_port_data_rate_sent_bytes_per_second{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 12.0
+zhmc_port_data_rate_sent_bytes_per_second{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 49.0
+zhmc_port_data_rate_sent_bytes_per_second{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 6.0
+zhmc_port_data_rate_sent_bytes_per_second{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_data_rate_sent_bytes_per_second{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 12.0
+zhmc_port_data_rate_sent_bytes_per_second{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 475.0
+zhmc_port_data_rate_sent_bytes_per_second{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_data_rate_sent_bytes_per_second{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 23686.0
+zhmc_port_data_rate_sent_bytes_per_second{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 6.0
 # HELP zhmc_port_data_rate_received_bytes_per_second Data rate received over the collection interval
 # TYPE zhmc_port_data_rate_received_bytes_per_second gauge
-zhmc_port_data_rate_received_bytes_per_second{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 748.0
-zhmc_port_data_rate_received_bytes_per_second{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 167.0
-zhmc_port_data_rate_received_bytes_per_second{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_data_rate_received_bytes_per_second{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 25.0
-zhmc_port_data_rate_received_bytes_per_second{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 690.0
-zhmc_port_data_rate_received_bytes_per_second{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_data_rate_received_bytes_per_second{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 465.0
-zhmc_port_data_rate_received_bytes_per_second{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 12.0
+zhmc_port_data_rate_received_bytes_per_second{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 69.0
+zhmc_port_data_rate_received_bytes_per_second{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 149.0
+zhmc_port_data_rate_received_bytes_per_second{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_data_rate_received_bytes_per_second{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 14.0
+zhmc_port_data_rate_received_bytes_per_second{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 1005.0
+zhmc_port_data_rate_received_bytes_per_second{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_data_rate_received_bytes_per_second{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 102865.0
+zhmc_port_data_rate_received_bytes_per_second{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 27.0
 # HELP zhmc_port_bandwidth_usage_ratio Bandwidth usage ratio of the port
 # TYPE zhmc_port_bandwidth_usage_ratio gauge
-zhmc_port_bandwidth_usage_ratio{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_bandwidth_usage_ratio{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_bandwidth_usage_ratio{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_bandwidth_usage_ratio{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_bandwidth_usage_ratio{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_bandwidth_usage_ratio{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",pod="wdc04-05",port="1"} 0.0
-zhmc_port_bandwidth_usage_ratio{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
-zhmc_port_bandwidth_usage_ratio{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",pod="wdc04-05",port="0"} 0.0
+zhmc_port_bandwidth_usage_ratio{adapter="OSD_134_DATA_NET2_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_bandwidth_usage_ratio{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_bandwidth_usage_ratio{adapter="OSD_108_MGMT_NET1_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_bandwidth_usage_ratio{adapter="OSD_130_DATA_NET1_17",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_bandwidth_usage_ratio{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_bandwidth_usage_ratio{adapter="OSD_128_MGMT_NET2_30",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="1"} 0.0
+zhmc_port_bandwidth_usage_ratio{adapter="OSD_110_DATA_NET1_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+zhmc_port_bandwidth_usage_ratio{adapter="OSD_114_DATA_NET2_15",cpc="CPCA",mzr="US-East",pod="wdc04-05",port="0"} 0.0
+# HELP zhmc_partition_processor_mode_int Allocation mode for processors to the active partition as an integer (0=shared, 1=dedicated)
+# TYPE zhmc_partition_processor_mode_int gauge
+zhmc_partition_processor_mode_int{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_partition_processor_mode_int{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_partition_processor_mode_int{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 0.0
+# HELP zhmc_partition_threads_per_processor_ratio Number of threads per allocated processor the operating system running in the partition is configured to use
+# TYPE zhmc_partition_threads_per_processor_ratio gauge
+zhmc_partition_threads_per_processor_ratio{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 1.0
+zhmc_partition_threads_per_processor_ratio{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 2.0
+zhmc_partition_threads_per_processor_ratio{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 2.0
+# HELP zhmc_partition_cp_processor_count Number of CP processors allocated to the active partition
+# TYPE zhmc_partition_cp_processor_count gauge
+zhmc_partition_cp_processor_count{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_partition_cp_processor_count{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_partition_cp_processor_count{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 0.0
+# HELP zhmc_partition_cp_initial_processing_weight Initial CP processing weight for the active partition in shared mode (1..999)
+# TYPE zhmc_partition_cp_initial_processing_weight gauge
+zhmc_partition_cp_initial_processing_weight{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 100.0
+zhmc_partition_cp_initial_processing_weight{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 100.0
+zhmc_partition_cp_initial_processing_weight{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 100.0
+# HELP zhmc_partition_cp_minimum_processing_weight Minimum CP processing weight for the active partition in shared mode (1..999)
+# TYPE zhmc_partition_cp_minimum_processing_weight gauge
+zhmc_partition_cp_minimum_processing_weight{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 1.0
+zhmc_partition_cp_minimum_processing_weight{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 1.0
+zhmc_partition_cp_minimum_processing_weight{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 1.0
+# HELP zhmc_partition_cp_maximum_processing_weight Maximum CP processing weight for the active partition in shared mode (1..999)
+# TYPE zhmc_partition_cp_maximum_processing_weight gauge
+zhmc_partition_cp_maximum_processing_weight{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 999.0
+zhmc_partition_cp_maximum_processing_weight{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 999.0
+zhmc_partition_cp_maximum_processing_weight{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 999.0
+# HELP zhmc_partition_cp_current_processing_weight Current CP processing weight for the active partition in shared mode (1..999)
+# TYPE zhmc_partition_cp_current_processing_weight gauge
+zhmc_partition_cp_current_processing_weight{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 1.0
+zhmc_partition_cp_current_processing_weight{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 1.0
+zhmc_partition_cp_current_processing_weight{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 1.0
+# HELP zhmc_partition_cp_processor_count_cap Maximum number of CP processors to be used when absolute CP processor capping is enabled
+# TYPE zhmc_partition_cp_processor_count_cap gauge
+zhmc_partition_cp_processor_count_cap{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 1.0
+zhmc_partition_cp_processor_count_cap{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 1.0
+zhmc_partition_cp_processor_count_cap{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 1.0
+# HELP zhmc_partition_cp_initial_processing_weight_is_capped Boolean indicating whether the initial CP processing weight is capped (i.e. a limit) or not (i.e. a target).
+# TYPE zhmc_partition_cp_initial_processing_weight_is_capped gauge
+zhmc_partition_cp_initial_processing_weight_is_capped{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_partition_cp_initial_processing_weight_is_capped{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_partition_cp_initial_processing_weight_is_capped{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 0.0
+# HELP zhmc_partition_ifl_processor_count Number of IFL processors allocated to the active partition
+# TYPE zhmc_partition_ifl_processor_count gauge
+zhmc_partition_ifl_processor_count{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 2.0
+zhmc_partition_ifl_processor_count{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 2.0
+zhmc_partition_ifl_processor_count{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 4.0
+# HELP zhmc_partition_ifl_initial_processing_weight Initial IFL processing weight for the active partition in shared mode (1..999)
+# TYPE zhmc_partition_ifl_initial_processing_weight gauge
+zhmc_partition_ifl_initial_processing_weight{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 20.0
+zhmc_partition_ifl_initial_processing_weight{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 20.0
+zhmc_partition_ifl_initial_processing_weight{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 80.0
+# HELP zhmc_partition_ifl_minimum_processing_weight Minimum IFL processing weight for the active partition in shared mode (1..999)
+# TYPE zhmc_partition_ifl_minimum_processing_weight gauge
+zhmc_partition_ifl_minimum_processing_weight{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 1.0
+zhmc_partition_ifl_minimum_processing_weight{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 1.0
+zhmc_partition_ifl_minimum_processing_weight{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 1.0
+# HELP zhmc_partition_ifl_maximum_processing_weight Maximum IFL processing weight for the active partition in shared mode (1..999)
+# TYPE zhmc_partition_ifl_maximum_processing_weight gauge
+zhmc_partition_ifl_maximum_processing_weight{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 999.0
+zhmc_partition_ifl_maximum_processing_weight{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 999.0
+zhmc_partition_ifl_maximum_processing_weight{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 999.0
+# HELP zhmc_partition_ifl_current_processing_weight Current IFL processing weight for the active partition in shared mode (1..999)
+# TYPE zhmc_partition_ifl_current_processing_weight gauge
+zhmc_partition_ifl_current_processing_weight{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 1.0
+zhmc_partition_ifl_current_processing_weight{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 1.0
+zhmc_partition_ifl_current_processing_weight{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 1.0
+# HELP zhmc_partition_ifl_processor_count_cap Maximum number of IFL processors to be used when absolute IFL processor capping is enabled
+# TYPE zhmc_partition_ifl_processor_count_cap gauge
+zhmc_partition_ifl_processor_count_cap{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 1.0
+zhmc_partition_ifl_processor_count_cap{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 1.0
+zhmc_partition_ifl_processor_count_cap{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 1.0
+# HELP zhmc_partition_ifl_initial_processing_weight_is_capped Boolean indicating whether the initial IFL processing weight is capped (i.e. a limit) or not (i.e. a target).
+# TYPE zhmc_partition_ifl_initial_processing_weight_is_capped gauge
+zhmc_partition_ifl_initial_processing_weight_is_capped{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_partition_ifl_initial_processing_weight_is_capped{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_partition_ifl_initial_processing_weight_is_capped{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 0.0
+# HELP zhmc_partition_initial_memory_mib Initial amount of memory allocated to the partition when it becomes active, in MiB
+# TYPE zhmc_partition_initial_memory_mib gauge
+zhmc_partition_initial_memory_mib{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 68608.0
+zhmc_partition_initial_memory_mib{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 122880.0
+zhmc_partition_initial_memory_mib{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 614400.0
+# HELP zhmc_partition_reserved_memory_mib Amount of reserved memory (maximum memory minus initial memory), in MiB
+# TYPE zhmc_partition_reserved_memory_mib gauge
+zhmc_partition_reserved_memory_mib{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 0.0
+zhmc_partition_reserved_memory_mib{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 0.0
+zhmc_partition_reserved_memory_mib{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 0.0
+# HELP zhmc_partition_maximum_memory_mib Maximum amount of memory to which the operating system running in the partition can increase the memory allocation, in MiB
+# TYPE zhmc_partition_maximum_memory_mib gauge
+zhmc_partition_maximum_memory_mib{cpc="CPCA",mzr="US-East",partition="MIKETEST",pod="wdc04-05"} 68608.0
+zhmc_partition_maximum_memory_mib{cpc="CPCA",mzr="US-East",partition="WILLVLAN2",pod="wdc04-05"} 122880.0
+zhmc_partition_maximum_memory_mib{cpc="CPCA",mzr="US-East",partition="PENNY",pod="wdc04-05"} 614400.0
+# HELP zhmc_cpc_cp_processor_count Number of active CP processors
+# TYPE zhmc_cpc_cp_processor_count gauge
+zhmc_cpc_cp_processor_count{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+# HELP zhmc_cpc_ifl_processor_count Number of active IFL processors
+# TYPE zhmc_cpc_ifl_processor_count gauge
+zhmc_cpc_ifl_processor_count{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 30.0
+# HELP zhmc_cpc_icf_processor_count Number of active ICF processors
+# TYPE zhmc_cpc_icf_processor_count gauge
+zhmc_cpc_icf_processor_count{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+# HELP zhmc_cpc_iip_processor_count Number of active zIIP processors
+# TYPE zhmc_cpc_iip_processor_count gauge
+zhmc_cpc_iip_processor_count{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+# HELP zhmc_cpc_aap_processor_count Number of active zAAP processors
+# TYPE zhmc_cpc_aap_processor_count gauge
+zhmc_cpc_aap_processor_count{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+# HELP zhmc_cpc_cbp_processor_count Number of active CBP processors
+# TYPE zhmc_cpc_cbp_processor_count gauge
+zhmc_cpc_cbp_processor_count{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+# HELP zhmc_cpc_sap_processor_count Number of active SAP processors
+# TYPE zhmc_cpc_sap_processor_count gauge
+zhmc_cpc_sap_processor_count{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 2.0
+# HELP zhmc_cpc_defective_processor_count Number of defective processors of all processor types
+# TYPE zhmc_cpc_defective_processor_count gauge
+zhmc_cpc_defective_processor_count{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+# HELP zhmc_cpc_spare_processor_count Number of spare processors of all processor types
+# TYPE zhmc_cpc_spare_processor_count gauge
+zhmc_cpc_spare_processor_count{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+# HELP zhmc_cpc_total_memory_mib Total amount of installed memory, in MiB
+# TYPE zhmc_cpc_total_memory_mib gauge
+zhmc_cpc_total_memory_mib{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 4.194304e+06
+# HELP zhmc_cpc_hsa_memory_mib Amount of memory reserved for the base hardware system area (HSA), in MiB
+# TYPE zhmc_cpc_hsa_memory_mib gauge
+zhmc_cpc_hsa_memory_mib{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 65536.0
+# HELP zhmc_cpc_partition_memory_mib Amount of memory for use by partitions, in MiB
+# TYPE zhmc_cpc_partition_memory_mib gauge
+zhmc_cpc_partition_memory_mib{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 4.128768e+06
+# HELP zhmc_cpc_partition_central_memory_mib Amount of memory allocated as central storage across the active partitions, in MiB
+# TYPE zhmc_cpc_partition_central_memory_mib gauge
+zhmc_cpc_partition_central_memory_mib{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 2.280448e+06
+# HELP zhmc_cpc_partition_expanded_memory_mib Amount of memory allocated as expanded storage across the active partitions, in MiB
+# TYPE zhmc_cpc_partition_expanded_memory_mib gauge
+zhmc_cpc_partition_expanded_memory_mib{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0
+# HELP zhmc_cpc_available_memory_mib Amount of memory not allocated to active partitions, in MiB
+# TYPE zhmc_cpc_available_memory_mib gauge
+zhmc_cpc_available_memory_mib{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 1.84832e+06
+# HELP zhmc_cpc_vfm_increment_gib Increment size of IBM Virtual Flash Memory (VFM), in GiB
+# TYPE zhmc_cpc_vfm_increment_gib gauge
+zhmc_cpc_vfm_increment_gib{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 16.0
+# HELP zhmc_cpc_total_vfm_gib Total amount of installed IBM Virtual Flash Memory (VFM), in GiB
+# TYPE zhmc_cpc_total_vfm_gib gauge
+zhmc_cpc_total_vfm_gib{cpc="CPCA",mzr="US-East",pod="wdc04-05"} 0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,15 @@
 # of appearance.
 #
 
-# git+https://github.com/zhmcclient/python-zhmcclient.git@master#egg=zhmcclient
-zhmcclient>=0.31.0 # Apache-2.0
+# TODO: Use zhmcclient 1.0.0 once released
+git+https://github.com/zhmcclient/python-zhmcclient.git@master#egg=zhmcclient
+# zhmcclient>=1.0.0 # Apache-2.0
 
 prometheus-client>=0.3.1 # Apache-2.0
 urllib3>=1.24.0
 jsonschema>=2.6.0
 six>=1.14.0 # MIT
+jinja2>=2.0.0
 
 # PyYAML pulled in by zhmcclient examples
 # PyYAML 5.3 fixes narrow build error

--- a/zhmc_prometheus_exporter/schemas/metrics_schema.yaml
+++ b/zhmc_prometheus_exporter/schemas/metrics_schema.yaml
@@ -9,18 +9,26 @@ required:
 additionalProperties: false
 properties:
   metric_groups:
-    description: The HMC metric groups and their mapping to Prometheus
+    description: The HMC and resource metric groups and their mapping to Prometheus
     type: object
     additionalProperties: false
     patternProperties:
       "^[a-z0-9\\-]+$":
-        description: "Key: Name of the HMC metric group"
+        description: "Key: Name of the HMC or resource metric group"
         type: object
         required:
           - prefix
           - fetch
         additionalProperties: false
         properties:
+          type:
+            description: "The type of metric group: metric - an HMC metric group in which the metric values come from the HMC metric service; resource - an artificial metric group in which the metric values come from resource properties."
+            type: string
+            enum: [metric, resource]
+            default: metric
+          resource:
+            description: "The resource class path for a resource metric group, starting at the zhmcclient.Client object (e.g. 'cpc.partition')."
+            type: string
           prefix:
             description: "<prefix> part of Prometheus metric name (format: zhmc_<prefix>_<metric_unit>)"
             type: string
@@ -57,17 +65,53 @@ properties:
     patternProperties:
       "^[a-z0-9\\-]+$":
         description: "Key: Name of the HMC metric group"
-        type: object
-        additionalProperties: false
-        patternProperties:
-          "^[a-zA-Z0-9\\-]+$":
-            description: "Key: Name of the HMC metric within its metric group"
+        oneOf:
+        - description: "Value: Mapping to Promentheus metrics in dictionary format (must be used for HMC metric values, can be used for HMC property based metrics)"
+          type: object
+          additionalProperties: false
+          patternProperties:
+            "^[a-zA-Z0-9\\-]+$":
+              description: "Key: Name of the HMC metric within its HMC metric group, or HMC resource property name"
+              type: object
+              required:
+                - exporter_name
+                - exporter_desc
+              additionalProperties: false
+              properties:
+                exporter_name:
+                  description: "<metric_unit> part of Prometheus metric name (format: zhmc_<prefix>_<metric_unit>); Null causes the metric not to be exported to Prometheus"
+                  type: [string, "null"]
+                  pattern: "^[a-zA-Z0-9_]+$"
+                exporter_desc:
+                  description: "HELP description of Prometheus metric"
+                  type: [string, "null"]
+                percent:
+                  description: "Indicates whether the original HMC value is represented as percentage with a value of 100 meaning 100%"
+                  type: boolean
+                  default: false
+                valuemap:
+                  description: "Defines how string values in the original HMC value are mapped into integer values exported by Prometheus"
+                  type: object
+                  additionalProperties: false
+                  patternProperties:
+                    "^[a-zA-Z0-9\\-]+$":
+                      description: "Key: String value in original HMC value. Value: Integer value exported by Prometheus"
+                      type: integer
+        - description: "Value: Mapping to Promentheus metrics in list format (can be used for HMC property based metrics)"
+          type: array
+          items:
             type: object
             required:
               - exporter_name
               - exporter_desc
             additionalProperties: false
             properties:
+              property_name:
+                description: "Name of the HMC property on the resource to use as the metric value"
+                type: string
+              properties_expression:
+                description: "Jinja2 expression on 'properties' variable to use as the metric value"
+                type: string
               exporter_name:
                 description: "<metric_unit> part of Prometheus metric name (format: zhmc_<prefix>_<metric_unit>); Null causes the metric not to be exported to Prometheus"
                 type: [string, "null"]
@@ -76,6 +120,14 @@ properties:
                 description: "HELP description of Prometheus metric"
                 type: [string, "null"]
               percent:
-                description: "Indicates whether the HMC metric value is represented as percentage with a value of 100 meaning 100%"
+                description: "Indicates whether the original HMC value is represented as percentage with a value of 100 meaning 100%"
                 type: boolean
                 default: false
+              valuemap:
+                description: "Defines how string values in the original HMC value are mapped into integer values exported by Prometheus"
+                type: object
+                additionalProperties: false
+                patternProperties:
+                  "^[a-zA-Z0-9\\-]+$":
+                    description: "Key: String value in original HMC value. Value: Integer value exported by Prometheus"
+                    type: integer


### PR DESCRIPTION
For details, see commit message.
No more TODOs left at this point, ready for review and merge.

To try out this PR:
- perform a fresh install of the exporter from this branch, which will pull in the required zhmcclient branch.
- use the updated examples/metrics.yaml file
- you should see resource property based metrics for CPCs and partitions/LPARs.