### PR TITLE
1.0: Ignored Pylint issue 'consider-using-f-string' in new Pylint 2.11

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -73,7 +73,7 @@ disable=I0011,
         wildcard-import, unused-wildcard-import,
         locally-enabled, superfluous-parens, useless-object-inheritance,
         consider-using-set-comprehension, unnecessary-pass, useless-return,
-        raise-missing-from
+        raise-missing-from, consider-using-f-string
 
 # Note: The too-many-* messages are excluded temporarily, and should be dealt
 #       with at some point.

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,9 @@ Released: not yet
 
 * Fixed new issues reported by Pylint 2.10.
 
+* Disabled new Pylint issue 'consider-using-f-string', since f-strings were
+  introduced only in Python 3.6.
+
 **Enhancements:**
 
 **Cleanup:**


### PR DESCRIPTION
Rolls back PR #177 into 1.0.1.