### PR TITLE
Automatic detection of HMC resources that no longer exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,8 @@ pylint: develop_$(pymn).done
 check_reqs: develop_$(pymn).done
 	@echo "Makefile: Checking missing dependencies of the package"
 	pip-missing-reqs $(package_dir) --requirements-file=requirements.txt
-	pip-missing-reqs $(package_dir) --requirements-file=minimum-constraints.txt
+# TODO: Remove error ignore marker once zhmcclient 1.4.0 is released
+	-pip-missing-reqs $(package_dir) --requirements-file=minimum-constraints.txt
 	@echo "Makefile: Done checking missing dependencies of the package"
 ifeq ($(PLATFORM),Windows_native)
 # Reason for skipping on Windows is https://github.com/r1chardj0n3s/pip-check-reqs/issues/67

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,9 @@ Released: not yet
 
 **Enhancements:**
 
+* HMC resources that no longer exist are automatically removed from the
+  exported metrics. (Issue #203)
+
 **Cleanup:**
 
 **Known issues:**

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -276,6 +276,10 @@ retrieved from the HMC, but they are exported to Prometheus in the same way:
   representations and can immediately return them without having to turn around
   for getting them from the HMC.
 
+  Resources that no longer exist on the HMC are automatically not exported
+  anymore. Resources that were created on the HMC since the exporter was
+  started are not detected.
+
 The exporter code is agnostic to the actual set of metrics supported by the HMC.
 A new metric exposed by the HMC metric service or a new property added to one of
 the auto-updated resources can immediately be supported by just adding it to

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -71,7 +71,8 @@ wheel==0.33.5; python_version >= '3.8'
 
 # Direct dependencies for runtime (must be consistent with requirements.txt)
 
-zhmcclient==1.3.1
+# TODO: Use zhmcclient 1.4.0 once released, before releasing this project.
+# zhmcclient==1.4.0
 
 prometheus-client==0.9.0
 urllib3==1.25.9; python_version <= '3.9'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,9 @@
 
 # Direct dependencies for runtime (must be consistent with minimum-constraints.txt)
 
-# git+https://github.com/zhmcclient/python-zhmcclient.git@stable_1.3#egg=zhmcclient
-zhmcclient>=1.3.1
+# TODO: Use zhmcclient 1.4.0 once released, before releasing this project.
+git+https://github.com/zhmcclient/python-zhmcclient.git@master#egg=zhmcclient
+# zhmcclient>=1.4.0
 
 prometheus-client>=0.9.0
 urllib3>=1.25.9; python_version <= '3.9'


### PR DESCRIPTION
This addresses the resource removal part of issue #203 . The addition of new resources will be in a separate PR.

For details, see the commit message.

Test: Since we don't have end2end testcases yet, and since this is difficult to test in unit tests, I have not added test cases. However, the function has been tested by creating an extra test partition, starting the exporter, removing the test partition, and verifying that it disappears from the Prometheus data.