### PR TITLE
Renamed LPAR status metric to 'zhmc_partition_lpar_status_int'

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -26,6 +26,11 @@ Released: not yet
 
 **Incompatible changes:**
 
+* For classic mode CPCs, changed the name of the LPAR status metric from
+  `zhmc_partition_status_int` to `zhmc_partition_lpar_status_int` in order to
+  disambiguate it from the same-named metric for partitions on CPCs in DPM
+  mode. (issue #207)
+
 **Deprecations:**
 
 **Bug fixes:**

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -495,7 +495,8 @@ zhmc_partition_maximum_expanded_memory_mib              C     G     Maximum amou
 zhmc_partition_initial_vfm_memory_gib                   C     G     Initial amount of VFM memory to be allocated at partition activation, in GiB
 zhmc_partition_maximum_vfm_memory_gib                   C     G     Maximum amount of VFM memory that can be allocated to the active partition, in GiB
 zhmc_partition_current_vfm_memory_gib                   C     G     Current amount of VFM memory that is allocated to the active partition, in GiB
-zhmc_partition_status_int                               C+D   G     Status as integer (values depend on classic mode vs DPM mode)
+zhmc_partition_status_int                               D     G     Partition status as integer (0=active, 1=degraded, 10=paused, 11=stopped, 12=starting, 13=stopping, 20=reservation-error, 21=terminated, 22=communications-not-active, 23=status-check, 99=unsupported value)
+zhmc_partition_lpar_status_int                          C     G     LPAR status as integer (0=operating, 1=not-operating, 2=not-activated, 10=exceptions, 99=unsupported value)
 zhmc_partition_has_unacceptable_status                  C+D   G     Boolean indicating whether the partition has an unacceptable status
 zhmc_crypto_adapter_usage_ratio                         C     G     Usage ratio of the crypto adapter
 zhmc_flash_memory_adapter_usage_ratio                   C     G     Usage ratio of the flash memory adapter

--- a/examples/metrics.yaml
+++ b/examples/metrics.yaml
@@ -574,8 +574,8 @@ metrics:
       exporter_name: current_vfm_memory_gib
       exporter_desc: Current amount of IBM Virtual Flash Memory (VFM) that is allocated to the active partition, in GiB
     - properties_expression: "{'operating': 0, 'not-operating': 1, 'not-activated': 2, 'exceptions': 10}.get(properties.status, 99)"
-      exporter_name: status_int
-      exporter_desc: "Status as integer (0=operating, 1=not-operating, 2=not-activated, 10=exceptions, 99=unsupported value; see Logical Partition property 'status')"
+      exporter_name: lpar_status_int
+      exporter_desc: "LPAR status as integer (0=operating, 1=not-operating, 2=not-activated, 10=exceptions, 99=unsupported value)"
     - property_name: has-unacceptable-status
       exporter_name: has_unacceptable_status
       exporter_desc: Boolean indicating whether the partition has an unacceptable status (0=false, 1=true)
@@ -914,7 +914,7 @@ metrics:
       exporter_desc: Maximum amount of memory to which the operating system running in the partition can increase the memory allocation, in MiB
     - properties_expression: "{'active': 0, 'degraded': 1, 'paused': 10, 'stopped': 11, 'starting': 12, 'stopping': 13, 'reservation-error': 20, 'terminated': 21, 'communications-not-active': 22, 'status-check': 23}.get(properties.status, 99)"
       exporter_name: status_int
-      exporter_desc: "Status as integer (0=active, 1=degraded, 10=paused, 11=stopped, 12=starting, 13=stopping, 20=reservation-error, 21=terminated, 22=communications-not-active, 23=status-check, 99=unsupported value; see Partition property 'status')"
+      exporter_desc: "Partition status as integer (0=active, 1=degraded, 10=paused, 11=stopped, 12=starting, 13=stopping, 20=reservation-error, 21=terminated, 22=communications-not-active, 23=status-check, 99=unsupported value)"
     - property_name: has-unacceptable-status
       exporter_name: has_unacceptable_status
       exporter_desc: Boolean indicating whether the partition has an unacceptable status (0=false, 1=true)
@@ -1184,7 +1184,7 @@ metrics:
       exporter_desc: Total amount of installed IBM Virtual Flash Memory (VFM), in GiB
     - properties_expression: "{'active': 0, 'operating': 0, 'degraded': 1, 'service-required': 2, 'service': 10, 'exceptions': 11, 'not-communicating': 12, 'status-check': 13, 'not-operating': 14, 'no-powerstatus': 15}.get(properties.status, 99)"
       exporter_name: status_int
-      exporter_desc: "Status as integer (0=active/=operating, 1=degraded, 2=service-required, 10=service, 11=exceptions, 12=not-communicating, 13=status-check, 14=not-operating, 15=no-power, 99=unsupported value; see CPC property 'status')"
+      exporter_desc: "Status as integer (0=active/=operating, 1=degraded, 2=service-required, 10=service, 11=exceptions, 12=not-communicating, 13=status-check, 14=not-operating, 15=no-power, 99=unsupported value)"
     - property_name: has-unacceptable-status
       exporter_name: has_unacceptable_status
       exporter_desc: Boolean indicating whether the CPC has an unacceptable status (0=false, 1=true)


### PR DESCRIPTION
For details, see the commit message.