### PR TITLE
Fixed error when `--log` is not specified

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,9 @@ Released: not yet
 
 **Bug fixes:**
 
+* Fixed that not using the `--log` option resulted in an error message
+  about invalid use of the `--log-comp` option. (issue #234)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
+++ b/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
@@ -221,7 +221,7 @@ def parse_args(args):
                         "({dests}). Default: no logging".
                         format(dests=', '.join(VALID_LOG_DESTINATIONS)))
     parser.add_argument("--log-comp", dest='log_complevels', action='append',
-                        metavar="COMP[=LEVEL]", default=[DEFAULT_LOG_COMP],
+                        metavar="COMP[=LEVEL]", default=None,
                         help="set a logging level ({levels}, default: "
                         "{def_level}) for a component ({comps}). May be "
                         "specified multiple times; options add to the default "


### PR DESCRIPTION
For details, see the commit message.
No review needed.