### PR TITLE
Fixed new issues of Pylint 2.16 and versions of Pylint dependents & Python

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -178,7 +178,10 @@ disable=I0011,
         wildcard-import, unused-wildcard-import,
         superfluous-parens, useless-object-inheritance,
         consider-using-set-comprehension, unnecessary-pass, useless-return,
-        raise-missing-from, consider-using-f-string
+        raise-missing-from, consider-using-f-string,
+        super-with-arguments, duplicate-string-formatting-argument,
+        consider-using-generator, bad-option-value, redundant-u-string-prefix,
+        use-implicit-booleaness-not-comparison, use-dict-literal,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -32,12 +32,15 @@ entrypoints>=0.3.0
 # Pylint 2.4 / astroid 2.3 supports py35 and higher
 # Pylint 2.7 / astroid 2.5 removed support for py35 and supports py36 and higher
 # Pylint fails to recognize the stat module as a standard module on Windows
-pylint>=2.6.0
-astroid>=2.4.0
-# typed-ast is used by astroid on py34..py37
-typed-ast>=1.4.0,<1.5.0; python_version <= '3.7' and implementation_name=='cpython'
-# Workaround: lazy-object-proxy is used by astroid
-lazy-object-proxy>=1.4.3
+pylint>=2.5.2,<2.7.0; python_version == '3.5'
+pylint>=2.10.0,<2.14.0; python_version == '3.6'
+pylint>=2.10.0; python_version >= '3.7'
+astroid>=2.4.0,<2.6.0; python_version == '3.5'
+astroid>=2.7.2; python_version >= '3.6'
+typed-ast>=1.4.0,<1.5.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
+# lazy-object-proxy is used by astroid
+lazy-object-proxy>=1.4.3; python_version >= '3.5'
+wrapt>=1.11.2; python_version >= '3.5'
 # platformdirs is used by pylint starting with its 2.10
 platformdirs>=2.2.0; python_version >= '3.6'
 

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -44,6 +44,9 @@ Released: not yet
 
 * Test: Fixed install error of Python 2.7, 3,5, 3,6 on Ubuntu in GitHub Actions.
 
+* Fixed new issues of Pylint 2.16. Fixed versions of Pylint dependents and their
+  Python versions.
+
 **Enhancements:**
 
 * Added support for labels on single metric definitions, for defining how the

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -136,11 +136,13 @@ pyflakes==2.4.0; python_version >= '3.10'
 entrypoints==0.3.0
 
 # PyLint (no imports, invoked via pylint script)
-pylint==2.6.0
-astroid==2.4.0
-# typed-ast is used by astroid on py34..py37
-typed-ast==1.4.0; python_version <= '3.7' and implementation_name=='cpython'
-lazy-object-proxy==1.4.3
+pylint==2.5.2; python_version == '3.5'
+pylint==2.10.0; python_version >= '3.6'
+astroid==2.4.0; python_version == '3.5'
+astroid==2.7.2; python_version >= '3.6'
+typed-ast==1.4.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
+lazy-object-proxy==1.4.3; python_version >= '3.5'
+wrapt==1.11.2; python_version >= '3.5'
 platformdirs==2.2.0; python_version >= '3.6'
 
 # Sphinx (no imports, invoked via sphinx-build script):
@@ -180,6 +182,7 @@ pip-check-reqs==2.3.2
 
 alabaster==0.7.9
 atomicwrites==1.4.0  # used with minimum package levels
+appdirs==1.4.3
 bleach==3.3.0
 chardet==3.0.4  # used with minimum package levels
 colorama==0.4.0
@@ -208,7 +211,6 @@ toml==0.10.0  # used by pylint and pytest since some version
 tqdm==4.28.1
 typing==3.6.1
 webencodings==0.5.1
-wrapt==1.11.2
 
 # used by pylint 2.14 which requires python_version >= '3.7' (or maybe earlier)
 dill==0.2; python_version >= '3.7'


### PR DESCRIPTION
For details, see the commit message.
No review needed.