### PR TITLE
Added 'cord' label to line cord power metrics

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -148,6 +148,9 @@ Released: not yet
 
 * Docs: Added a link to the description of Jinja2 expressions.
 
+* Added a 'cord' label with the line cord name to all 'zhmc_cpc_power_cord\*'
+  metrics.
+
 **Cleanup:**
 
 * Addressed issues in test workflow reported by Github Actions. (issue #264)

--- a/examples/metrics.yaml
+++ b/examples/metrics.yaml
@@ -1037,142 +1037,198 @@ metrics:
       exporter_desc: Exhaust temperature of the CPC
 
   environmental-power-status:
-    # linecord-one-name:
-    #   # type: info
-    #   percent: false
-    #   exporter_name: power_cord1_name
-    #   exporter_desc: Line cord 1 identifier - "not-connected" if not available
     linecord-one-power-phase-A:
       percent: false
       exporter_name: power_cord1_phase_a_watts
       exporter_desc: Power in Phase A of line cord 1 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-one-name']"
     linecord-one-power-phase-B:
       percent: false
       exporter_name: power_cord1_phase_b_watts
       exporter_desc: Power in Phase B of line cord 1 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-one-name']"
     linecord-one-power-phase-C:
       percent: false
       exporter_name: power_cord1_phase_c_watts
       exporter_desc: Power in Phase C of line cord 1 - 0 if not available
-    # linecord-two-name:
-    #   # type: info
-    #   percent: false
-    #   exporter_name: power_cord2_name
-    #   exporter_desc: Line cord 2 identifier - "not-connected" if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-one-name']"
+    linecord-one-name:
+      exporter_name: null  # Ignored (used as a label)
+      exporter_desc: null
     linecord-two-power-phase-A:
       percent: false
       exporter_name: power_cord2_phase_a_watts
       exporter_desc: Power in Phase A of line cord 2 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-two-name']"
     linecord-two-power-phase-B:
       percent: false
       exporter_name: power_cord2_phase_b_watts
       exporter_desc: Power in Phase B of line cord 2 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-two-name']"
     linecord-two-power-phase-C:
       percent: false
       exporter_name: power_cord2_phase_c_watts
       exporter_desc: Power in Phase C of line cord 2 - 0 if not available
-    # linecord-three-name:
-    #   # type: info
-    #   percent: false
-    #   exporter_name: power_cord3_name
-    #   exporter_desc: Line cord 3 identifier - "not-connected" if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-two-name']"
+    linecord-two-name:
+      exporter_name: null  # Ignored (used as a label)
+      exporter_desc: null
     linecord-three-power-phase-A:
       percent: false
       exporter_name: power_cord3_phase_a_watts
       exporter_desc: Power in Phase A of line cord 3 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-three-name']"
     linecord-three-power-phase-B:
       percent: false
       exporter_name: power_cord3_phase_b_watts
       exporter_desc: Power in Phase B of line cord 3 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-three-name']"
     linecord-three-power-phase-C:
       percent: false
       exporter_name: power_cord3_phase_c_watts
       exporter_desc: Power in Phase C of line cord 3 - 0 if not available
-    # linecord-four-name:
-    #   # type: info
-    #   percent: false
-    #   exporter_name: power_cord4_name
-    #   exporter_desc: Line cord 4 identifier - "not-connected" if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-three-name']"
+    linecord-three-name:
+      exporter_name: null  # Ignored (used as a label)
+      exporter_desc: null
     linecord-four-power-phase-A:
       percent: false
       exporter_name: power_cord4_phase_a_watts
       exporter_desc: Power in Phase A of line cord 4 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-four-name']"
     linecord-four-power-phase-B:
       percent: false
       exporter_name: power_cord4_phase_b_watts
       exporter_desc: Power in Phase B of line cord 4 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-four-name']"
     linecord-four-power-phase-C:
       percent: false
       exporter_name: power_cord4_phase_c_watts
       exporter_desc: Power in Phase C of line cord 4 - 0 if not available
-    # linecord-five-name:
-    #   # type: info
-    #   percent: false
-    #   exporter_name: power_cord5_name
-    #   exporter_desc: Line cord 5 identifier - "not-connected" if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-four-name']"
+    linecord-four-name:
+      exporter_name: null  # Ignored (used as a label)
+      exporter_desc: null
     linecord-five-power-phase-A:
       percent: false
       exporter_name: power_cord5_phase_a_watts
       exporter_desc: Power in Phase A of line cord 5 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-five-name']"
     linecord-five-power-phase-B:
       percent: false
       exporter_name: power_cord5_phase_b_watts
       exporter_desc: Power in Phase B of line cord 5 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-five-name']"
     linecord-five-power-phase-C:
       percent: false
       exporter_name: power_cord5_phase_c_watts
       exporter_desc: Power in Phase C of line cord 5 - 0 if not available
-    # linecord-six-name:
-    #   # type: info
-    #   percent: false
-    #   exporter_name: power_cord6_name
-    #   exporter_desc: Line cord 6 identifier - "not-connected" if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-five-name']"
+    linecord-five-name:
+      exporter_name: null  # Ignored (used as a label)
+      exporter_desc: null
     linecord-six-power-phase-A:
       percent: false
       exporter_name: power_cord6_phase_a_watts
       exporter_desc: Power in Phase A of line cord 6 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-six-name']"
     linecord-six-power-phase-B:
       percent: false
       exporter_name: power_cord6_phase_b_watts
       exporter_desc: Power in Phase B of line cord 6 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-six-name']"
     linecord-six-power-phase-C:
       percent: false
       exporter_name: power_cord6_phase_c_watts
       exporter_desc: Power in Phase C of line cord 6 - 0 if not available
-    # linecord-seven-name:
-    #   # type: info
-    #   percent: false
-    #   exporter_name: power_cord7_name
-    #   exporter_desc: Line cord 7 identifier - "not-connected" if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-six-name']"
+    linecord-six-name:
+      exporter_name: null  # Ignored (used as a label)
+      exporter_desc: null
     linecord-seven-power-phase-A:
       percent: false
       exporter_name: power_cord7_phase_a_watts
       exporter_desc: Power in Phase A of line cord 7 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-seven-name']"
     linecord-seven-power-phase-B:
       percent: false
       exporter_name: power_cord7_phase_b_watts
       exporter_desc: Power in Phase B of line cord 7 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-seven-name']"
     linecord-seven-power-phase-C:
       percent: false
       exporter_name: power_cord7_phase_c_watts
       exporter_desc: Power in Phase C of line cord 7 - 0 if not available
-    # linecord-eight-name:
-    #   # type: info
-    #   percent: false
-    #   exporter_name: power_cord8_name
-    #   exporter_desc: Line cord 8 identifier - "not-connected" if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-seven-name']"
+    linecord-seven-name:
+      exporter_name: null  # Ignored (used as a label)
+      exporter_desc: null
     linecord-eight-power-phase-A:
       percent: false
       exporter_name: power_cord8_phase_a_watts
       exporter_desc: Power in Phase A of line cord 8 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-eight-name']"
     linecord-eight-power-phase-B:
       percent: false
       exporter_name: power_cord8_phase_b_watts
       exporter_desc: Power in Phase B of line cord 8 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-eight-name']"
     linecord-eight-power-phase-C:
       percent: false
       exporter_name: power_cord8_phase_c_watts
       exporter_desc: Power in Phase C of line cord 8 - 0 if not available
+      labels:
+        - name: cord
+          value: "metric_values['linecord-eight-name']"
+    linecord-eight-name:
+      exporter_name: null  # Ignored (used as a label)
+      exporter_desc: null
 
   zcpc-processor-usage:
     processor-name:


### PR DESCRIPTION
For details, see the commit message.