### PR TITLE
Enabled 'partition-attached-network-interface' metric group

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -39,6 +39,11 @@ Released: not yet
 * Added a '--version' option for showing the versions of the exporter and
   the zhmcclient library. (issue #298)
 
+* Enabled the 'partition-attached-network-interface' metric group in the
+  standard/example metric definition file. It had been disabled for performance
+  reasons, but with the auto-update support for resources, there is no
+  visible performance impact anymore when Prometheus fetches the metrics.
+
 **Cleanup:**
 
 **Known issues:**

--- a/examples/metrics.yaml
+++ b/examples/metrics.yaml
@@ -116,7 +116,7 @@ metric_groups:
 
   partition-attached-network-interface:
     prefix: nic
-    fetch: false  # Takes about 1 minute for the initial processing
+    fetch: true
     if: "hmc_version>='2.13.1'"
     labels:
       - name: cpc


### PR DESCRIPTION
For details, see the commit message.