### PR TITLE
1.4: Enabled 'partition-attached-network-interface' metric group

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -32,6 +32,11 @@ Released: not yet
 
 **Enhancements:**
 
+* Enabled the 'partition-attached-network-interface' metric group in the
+  standard/example metric definition file. It had been disabled for performance
+  reasons, but with the auto-update support for resources, there is no
+  visible performance impact anymore when Prometheus fetches the metrics.
+
 **Cleanup:**
 
 **Known issues:**

--- a/examples/metrics.yaml
+++ b/examples/metrics.yaml
@@ -116,7 +116,7 @@ metric_groups:
 
   partition-attached-network-interface:
     prefix: nic
-    fetch: false  # Takes about 1 minute for the initial processing
+    fetch: true
     if: "hmc_version>='2.13.1'"
     labels:
       - name: cpc


### PR DESCRIPTION
Rolls back PR #317 into 1.4.1.