### PR TITLE
Added resource-based metrics for storage groups/volumes and partition attach

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -71,6 +71,10 @@ Released: not yet
   the 'value' label, for cases where the partition description contains further
   information that can be parsed. (issue #345)
 
+* Added resource-based metrics for storage groups and storage volumes. Added
+  a new metric zhmc_partition_storage_groups that lists the storage groups
+  attached to a partition. (issue #346)
+
 **Cleanup:**
 
 **Known issues:**

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -349,9 +349,9 @@ For more details on the resource properties of CPC and Partition (DPM mode)
 and Logical Partition (classic mode), see the corresponding data models
 in the :term:`HMC API` book.
 
-====================================  ====  ====  ===========================  ======================
+====================================  ====  ====  ===========================  ================================
 Exporter Metric Group                 Type  Mode  Prometheus Metrics           Prometheus Labels
-====================================  ====  ====  ===========================  ======================
+====================================  ====  ====  ===========================  ================================
 cpc-usage-overview                    M     C     zhmc_cpc_*                   cpc
 logical-partition-usage               M     C     zhmc_partition_*             cpc, partition
 channel-usage                         M     C     zhmc_channel_*               cpc, channel_css_chpid
@@ -369,7 +369,9 @@ zcpc-processor-usage                  M     C+D   zhmc_processor_*             c
 cpc-resource                          R     C+D   zhmc_cpc_*                   cpc
 partition-resource                    R     D     zhmc_partition_*             cpc, partition
 logical-partition-resource            R     C     zhmc_partition_*             cpc, partition
-====================================  ====  ====  ===========================  ======================
+storagegroup-resource                 R     D     zhmc_storagegroup_*          cpc, storagegroup
+storagevolume-resource                R     D     zhmc_storagevolume_*         cpc, storagegroup, storagevolume
+====================================  ====  ====  ===========================  ================================
 
 Legend:
 
@@ -556,6 +558,15 @@ zhmc_partition_current_vfm_memory_gib                   C     G     Current amou
 zhmc_partition_status_int                               D     G     Partition status as integer (0=active, 1=degraded, 10=paused, 11=stopped, 12=starting, 13=stopping, 20=reservation-error, 21=terminated, 22=communications-not-active, 23=status-check, 99=unsupported value)
 zhmc_partition_lpar_status_int                          C     G     LPAR status as integer (0=operating, 1=not-operating, 2=not-activated, 10=exceptions, 99=unsupported value)
 zhmc_partition_has_unacceptable_status                  C+D   G     Boolean indicating whether the partition has an unacceptable status
+zhmc_partition_storage_groups                           D     G     Storage groups attached to the partition, as a comma-separated list
+zhmc_storagegroup_type_int                              D     G     Storage group type as integer (0=fcp, 1=fc, 2=nvme, 99=unsupported value)
+zhmc_storagegroup_fulfillment_state_int                 D     G     Storage group fulfillment state as integer (0=complete, 1=pending, 2=pending-with-mismatches, 3=checking-migration, 4=incomplete, 99=unsupported value)
+zhmc_storagegroup_shared                                D     G     Boolean indicating whether the storage group is shared (0=false, 1=true)
+zhmc_storagegroup_max_partitions                        D     G     Maximum number of partitions a storage group can be attached to
+zhmc_storagevolume_fulfillment_state_int                D     G     Storage volume fulfillment state as integer (0=complete, 1=configuration-error, 2=deleting, 3=incomplete, 4=overprovisioned, 5=pending, 6=pending-with-mismatches, 99=unsupported value)
+zhmc_storagevolume_usage_int                            D     G     Usage of volume as integer (0=boot, 1=data, 2=not-applicable, 99=unsupported value)
+zhmc_storagevolume_size_gib                             D     G     Size of volume in GiB (0 for ECKD alias volumes)
+zhmc_storagevolume_cylinders                            D     G     Size of ECKD volume in cylinders (0 for ECKD alias volumes, not present for non-ECKD volumes)
 zhmc_crypto_adapter_usage_ratio                         C     G     Usage ratio of the crypto adapter
 zhmc_flash_memory_adapter_usage_ratio                   C     G     Usage ratio of the flash memory adapter
 zhmc_adapter_usage_ratio                                D     G     Usage ratio of the adapter

--- a/examples/metrics.yaml
+++ b/examples/metrics.yaml
@@ -137,6 +137,30 @@ metric_groups:
       - name: partition
         value: "resource_obj.name"
 
+  storagegroup-resource:
+    type: resource
+    resource: console.storagegroup
+    prefix: storagegroup
+    fetch: true
+    labels:
+      - name: cpc
+        value: "uri2resource(resource_obj.properties['cpc-uri']).name"
+      - name: storagegroup
+        value: "resource_obj.name"
+
+  storagevolume-resource:
+    type: resource
+    resource: console.storagevolume
+    prefix: storagevolume
+    fetch: true
+    labels:
+      - name: cpc
+        value: "uri2resource(resource_obj.manager.parent.properties['cpc-uri']).name"
+      - name: storagegroup
+        value: "resource_obj.manager.parent.name"
+      - name: storagevolume
+        value: "resource_obj.name"
+
   # Available for CPCs in any mode
 
   zcpc-environmentals-and-power:
@@ -1011,6 +1035,61 @@ metrics:
       labels:
         - name: valuetype
           value: "'bool'"
+    - properties_expression: "0"
+      exporter_name: storage_group_uris
+      exporter_desc: "URIs of storage groups attached to the partition, as a comma-separated list"
+      labels:
+        - name: value
+          value: "resource_obj.properties['storage-group-uris'] | join(',')"
+    - properties_expression: "0"
+      exporter_name: storage_groups
+      exporter_desc: "Storage groups attached to the partition, as a comma-separated list"
+      labels:
+        - name: value
+          value: "uris2resources(resource_obj.properties['storage-group-uris']) | map(attribute='name') | join(',')"
+
+  storagegroup-resource:  # can be in dictionary or list format
+    - properties_expression: "{'fcp': 0, 'fc': 1, 'nvme': 2}.get(properties.type, 99)"
+      exporter_name: type_int
+      exporter_desc: "Storage group type as integer (0=fcp, 1=fc, 2=nvme, 99=unsupported value)"
+      labels:
+        - name: value
+          value: "resource_obj.properties['type']"
+    - properties_expression: "{'complete': 0, 'pending': 1, 'pending-with-mismatches': 2, 'checking-migration': 3, 'incomplete': 4}.get(properties['fulfillment-state'], 99)"
+      exporter_name: fulfillment_state_int
+      exporter_desc: "Storage group fulfillment state as integer (0=complete, 1=pending, 2=pending-with-mismatches, 3=checking-migration, 4=incomplete, 99=unsupported value)"
+      labels:
+        - name: value
+          value: "resource_obj.properties['fulfillment-state']"
+    - property_name: shared
+      exporter_name: shared
+      exporter_desc: Boolean indicating whether the storage group is shared (0=false, 1=true)
+      labels:
+        - name: valuetype
+          value: "'bool'"
+    - property_name: max-partitions
+      exporter_name: max_partitions
+      exporter_desc: Maximum number of partitions a storage group can be attached to
+
+  storagevolume-resource:  # can be in dictionary or list format
+    - properties_expression: "{'complete': 0, 'configuration-error': 1, 'deleting': 2, 'incomplete': 3, 'overprovisioned': 4, 'pending': 5, 'pending-with-mismatches': 6}.get(properties['fulfillment-state'], 99)"
+      exporter_name: fulfillment_state_int
+      exporter_desc: "Storage volume fulfillment state as integer (0=complete, 1=configuration-error, 2=deleting, 3=incomplete, 4=overprovisioned, 5=pending, 6=pending-with-mismatches, 99=unsupported value)"
+      labels:
+        - name: value
+          value: "resource_obj.properties['fulfillment-state']"
+    - properties_expression: "{'boot': 0, 'data': 1, 'not-applicable': 2}.get(properties.usage, 99)"
+      exporter_name: usage_int
+      exporter_desc: "Usage of volume as integer (0=boot, 1=data, 2=not-applicable, 99=unsupported value)"
+      labels:
+        - name: value
+          value: "resource_obj.properties.usage"
+    - property_name: size
+      exporter_name: size_gib
+      exporter_desc: "Size of volume in GiB (0 for ECKD alias volumes)"
+    - property_name: cylinders
+      exporter_name: cylinders
+      exporter_desc: "Size of ECKD volume in cylinders (0 for ECKD alias volumes, not present for non-ECKD volumes)"
 
   # Available for CPCs in any mode
 

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -196,7 +196,7 @@ class TestCreateContext(unittest.TestCase):
         """Tests normal input with a generic metric group."""
         session = zhmcclient_mock.FakedSession("fake-host", "fake-hmc",
                                                "2.13.1", "1.8")
-        context, _ = zhmc_prometheus_exporter.create_metrics_context(
+        context, _, _ = zhmc_prometheus_exporter.create_metrics_context(
             session,
             {"dpm-system-usage-overview": {"prefix": "pre", "fetch": True}},
             '2.14')
@@ -412,8 +412,9 @@ class TestInitZHMCUsageCollector(unittest.TestCase):
         session = setup_faked_session()
         yaml_metric_groups = {"dpm-system-usage-overview": {"prefix": "pre",
                                                             "fetch": True}}
-        context, resources = zhmc_prometheus_exporter.create_metrics_context(
-            session, yaml_metric_groups, '2.14')
+        context, resources, _ = \
+            zhmc_prometheus_exporter.create_metrics_context(
+                session, yaml_metric_groups, '2.14')
         yaml_metrics = {
             "dpm-system-usage-overview": {
                 "processor-usage": {
@@ -429,7 +430,7 @@ class TestInitZHMCUsageCollector(unittest.TestCase):
 
         my_zhmc_usage_collector = zhmc_prometheus_exporter.ZHMCUsageCollector(
             cred_dict, session, context, resources, yaml_metric_groups,
-            yaml_metrics, extra_labels, "filename", "filename", None,
+            yaml_metrics, extra_labels, "filename", "filename", None, None,
             hmc_version, se_versions)
         self.assertEqual(my_zhmc_usage_collector.yaml_creds, cred_dict)
         self.assertEqual(my_zhmc_usage_collector.session, session)
@@ -451,8 +452,9 @@ class TestInitZHMCUsageCollector(unittest.TestCase):
                 "fetch": True
             }
         }
-        context, resources = zhmc_prometheus_exporter.create_metrics_context(
-            session, yaml_metric_groups, '2.14')
+        context, resources, _ = \
+            zhmc_prometheus_exporter.create_metrics_context(
+                session, yaml_metric_groups, '2.14')
         yaml_metrics = {
             "dpm-system-usage-overview": {
                 "processor-usage": {
@@ -468,7 +470,7 @@ class TestInitZHMCUsageCollector(unittest.TestCase):
 
         my_zhmc_usage_collector = zhmc_prometheus_exporter.ZHMCUsageCollector(
             cred_dict, session, context, resources, yaml_metric_groups,
-            yaml_metrics, extra_labels, "filename", "filename", None,
+            yaml_metrics, extra_labels, "filename", "filename", None, None,
             hmc_version, se_versions)
         collected = list(my_zhmc_usage_collector.collect())
         self.assertEqual(len(collected), 1)


### PR DESCRIPTION
For details, see the commit message.

Brief list of the new metrics:
```
zhmc_partition_storage_groups              Storage groups attached to the partition, as a comma-separated list

zhmc_storagegroup_type_int                 Storage group type as integer (0=fcp, 1=fc, 2=nvme, 99=unsupported value)
zhmc_storagegroup_fulfillment_state_int    Storage group fulfillment state as integer (0=complete, 1=pending, 2=pending-with-mismatches, 3=checking-migration, 4=incomplete, 99=unsupported value)
zhmc_storagegroup_shared                   Boolean indicating whether the storage group is shared (0=false, 1=true)
zhmc_storagegroup_max_partitions           Maximum number of partitions a storage group can be attached to

zhmc_storagevolume_fulfillment_state_int   Storage volume fulfillment state as integer (0=complete, 1=configuration-error, 2=deleting, 3=incomplete, 4=overprovisioned, 5=pending, 6=pending-with-mismatches, 99=unsupported value)
zhmc_storagevolume_usage_int               Usage of volume as integer (0=boot, 1=data, 2=not-applicable, 99=unsupported value)
zhmc_storagevolume_size_gib                Size of volume in GiB (0 for ECKD alias volumes)
zhmc_storagevolume_cylinders               Size of ECKD volume in cylinders (0 for ECKD alias volumes, not present for non-ECKD volumes)
```