### PR TITLE
Release 1.5.0b1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,52 +35,8 @@ jobs:
         if [[ "${{ github.event_name }}" == "schedule" || "${{ github.head_ref }}" =~ ^release_ ]]; then \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\", \"macos-latest\", \"windows-latest\" ], \
-            \"python-version\": [ \"3.5\", \"3.6\", \"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\" ], \
-            \"package_level\": [ \"minimum\", \"latest\" ], \
-            \"exclude\": [ \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"latest\" \
-              } \
-            ], \
-            \"include\": [ \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"latest\" \
-              } \
-            ] \
+            \"python-version\": [ \"3.8\", \"3.9\", \"3.10\", \"3.11\" ], \
+            \"package_level\": [ \"minimum\", \"latest\" ] \
           }" >> $GITHUB_OUTPUT; \
         else \
           echo "matrix={ \
@@ -89,23 +45,13 @@ jobs:
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"include\": [ \
               { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.8\", \
                 \"package_level\": \"minimum\" \
               }, \
               { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.6\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"macos-latest\", \
-                \"python-version\": \"3.5\", \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.8\", \
                 \"package_level\": \"latest\" \
               }, \
               { \
@@ -115,7 +61,7 @@ jobs:
               }, \
               { \
                 \"os\": \"windows-latest\", \
-                \"python-version\": \"3.5\", \
+                \"python-version\": \"3.8\", \
                 \"package_level\": \"latest\" \
               }, \
               { \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,11 @@ COPY examples/metrics.yaml /etc/zhmc-prometheus-exporter/metrics.yaml
 ENV TMP_DIR=/tmp/zhmc-prometheus-exporter
 WORKDIR $TMP_DIR
 COPY . $TMP_DIR
+
+# TODO: Remove git install again once PR https://github.com/prometheus/client_python/pull/946 is released on Pypi
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends git
+
 RUN pip install . && rm -rf $TMP_DIR
 
 # Set the current directory when running this image

--- a/Makefile
+++ b/Makefile
@@ -238,8 +238,9 @@ ifeq ($(python_m_version),2)
 	@echo "Makefile: Warning: Skipping the checking of missing dependencies on Python $(python_version)" >&2
 else
 	@echo "Makefile: Checking missing dependencies of this package"
-	pip-missing-reqs $(package_name) --requirements-file=requirements.txt
-	pip-missing-reqs $(package_name) --requirements-file=minimum-constraints.txt
+# TODO: Re-enable once PR https://github.com/prometheus/client_python/pull/946 is released as 0.18.0 (?)
+# pip-missing-reqs $(package_name) --requirements-file=requirements.txt
+# pip-missing-reqs $(package_name) --requirements-file=minimum-constraints.txt
 	@echo "Makefile: Done checking missing dependencies of this package"
 ifeq ($(PLATFORM),Windows_native)
 # Reason for skipping on Windows is https://github.com/r1chardj0n3s/pip-check-reqs/issues/67

--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,9 @@ Quickstart
   obtaining metrics, and which userid and password to use for logging on to
   the HMC.
 
+  It also defines whether HTTP or HTTPS is used for Prometheus, and HTTPS
+  related certificates and keys.
+
   Download the `sample HMC credentials file`_ as ``hmccreds.yaml`` and edit
   that copy accordingly.
 
@@ -107,8 +110,9 @@ Quickstart
   up and running. You can see what it does in the mean time by using the ``-v``
   option. Subsequent requests to the exporter will be sub-second.
 
-* Direct your web browser at http://localhost:9291 to see the exported
-  Prometheus metrics. Refreshing the browser will update the metrics.
+* Direct your web browser at http://localhost:9291 (or https://localhost:9291
+  when using HTTPS) to see the exported Prometheus metrics. Refreshing the
+  browser will update the metrics.
 
 Reporting issues
 ----------------

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,16 +17,15 @@ Change log
 ----------
 
 
-Version 1.5.0.dev1
-^^^^^^^^^^^^^^^^^^
+Version 1.5.0b1
+^^^^^^^^^^^^^^^
 
-This version contains all fixes up to version 1.4.x.
+This version contains all fixes up to version 1.4.2.
 
-Released: not yet
+Released: 2023-08-28
 
-**Incompatible changes:**
-
-**Deprecations:**
+Note: This is a beta release that installs the 'prometheus-client' package
+from https://github.com/andy-maier/client_python/tree/andy/review-add-tls
 
 **Bug fixes:**
 
@@ -85,14 +84,6 @@ Released: not yet
 
 * Added support for HTTPS and mutual TLS (mTLS) by adding a new section
   'prometheus' to the HMC credentials file. (issue #347)
-
-**Cleanup:**
-
-**Known issues:**
-
-* See `list of open issues`_.
-
-.. _`list of open issues`: https://github.com/zhmcclient/zhmc-prometheus-exporter/issues
 
 
 Version 1.4.0

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -83,6 +83,9 @@ Released: not yet
   a new metric zhmc_partition_storage_groups that lists the storage groups
   attached to a partition. (issue #346)
 
+* Added support for HTTPS and mutual TLS (mTLS) by adding a new section
+  'prometheus' to the HMC credentials file. (issue #347)
+
 **Cleanup:**
 
 **Known issues:**

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -27,6 +27,9 @@ automatic session renewals with the HMC if the logon session expires, and it
 survives HMC reboots and automatically picks up metrics collection again once
 the HMC come back up.
 
+The exporter supports HTTP and HTTPS (with and without mutual TLS) for
+Prometheus.
+
 .. _IBM Z: https://www.ibm.com/it-infrastructure/z
 .. _Prometheus exporter: https://prometheus.io/docs/instrumenting/exporters/
 .. _Prometheus: https://prometheus.io
@@ -52,6 +55,9 @@ Quickstart
   The HMC credentials file tells the exporter which HMC to talk to for
   obtaining metrics, and which userid and password to use for logging on to
   the HMC.
+
+  It also defines whether HTTP or HTTPS is used for Prometheus, and HTTPS
+  related certificates and keys.
 
   Download the :ref:`sample HMC credentials file` as ``hmccreds.yaml`` and edit
   that copy accordingly.
@@ -86,8 +92,9 @@ Quickstart
   up and running. You can see what it does in the mean time by using the ``-v``
   option. Subsequent requests to the exporter will be sub-second.
 
-* Direct your web browser at http://localhost:9291 to see the exported
-  Prometheus metrics. Refreshing the browser will update the metrics.
+* Direct your web browser at http://localhost:9291 (or https://localhost:9291
+  when using HTTPS) to see the exported Prometheus metrics. Refreshing the
+  browser will update the metrics.
 
 Reporting issues
 ----------------

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -38,7 +38,7 @@ Supported environments
 ----------------------
 
 * Operating systems: Linux, macOS, Windows
-* Python versions: 3.5 and higher
+* Python versions: 3.8 and higher
 * HMC versions: 2.11.1 and higher
 
 Quickstart

--- a/examples/hmccreds.yaml
+++ b/examples/hmccreds.yaml
@@ -6,6 +6,16 @@ metrics:
   password: password
   verify_cert: true
 
+prometheus:
+  port: 9291
+
+  # Note: Activating the following two parameters enables the use of HTTPS
+  # server_cert_file: server_cert.pem
+  # server_key_file: server_key.pem
+
+  # Note: Activating the following parameter enables the use of mutual TLS
+  # ca_cert_file: ca_certs.pem
+
 extra_labels:
   - name: hmc
     value: "hmc_info['hmc-name']"

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -80,7 +80,10 @@ wheel==0.38.1; python_version >= '3.7'
 
 zhmcclient==1.9.1
 
-prometheus-client==0.9.0
+# TODO: Re-enable once PR https://github.com/prometheus/client_python/pull/946 is released on Pypi
+# prometheus-client==0.9.0; python_version <= '3.7'
+# prometheus-client==0.18.0; python_version >= '3.8'
+
 urllib3==1.26.5
 jsonschema==3.2.0
 six==1.14.0; python_version <= '3.9'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,12 @@
 # zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
 zhmcclient>=1.9.1
 
-prometheus-client>=0.9.0
+# TODO: Re-enable once PR https://github.com/prometheus/client_python/pull/946 is released on Pypi
+# prometheus-client>=0.9.0; python_version <= '3.7'
+# prometheus-client>=0.18.0; python_version >= '3.8'
+prometheus-client @ git+https://github.com/andy-maier/client_python.git@release_0.17.1.post1
+
+
 urllib3>=1.25.9; python_version <= '3.9'
 urllib3>=1.26.5; python_version >= '3.10'
 jsonschema>=3.2.0

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setuptools.setup(
 
     # Keep these Python versions in sync with:
     # - Section "Supported environments" in docs/intro.rst
-    python_requires='>=3.5',
+    python_requires='>=3.8',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
@@ -130,9 +130,6 @@ setuptools.setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -46,7 +46,7 @@ class TestParseArgs(unittest.TestCase):
     def test_default_args(self):
         """Tests for all defaults."""
         args = zhmc_prometheus_exporter.zhmc_prometheus_exporter.parse_args([])
-        self.assertEqual(args.p, "9291")
+        self.assertEqual(args.p, None)
         self.assertEqual(args.c, "/etc/zhmc-prometheus-exporter/hmccreds.yaml")
         self.assertEqual(args.m, "/etc/zhmc-prometheus-exporter/metrics.yaml")
 

--- a/zhmc_prometheus_exporter/_version.py
+++ b/zhmc_prometheus_exporter/_version.py
@@ -25,4 +25,4 @@ __all__ = ['__version__']
 #:
 #: * "M.N.P.dev1": A not yet released version M.N.P
 #: * "M.N.P": A released version M.N.P
-__version__ = '1.5.0.dev1'
+__version__ = '1.5.0b1'

--- a/zhmc_prometheus_exporter/schemas/hmccreds_schema.yaml
+++ b/zhmc_prometheus_exporter/schemas/hmccreds_schema.yaml
@@ -29,6 +29,23 @@ properties:
       verify_cert:
         description: "Controls whether and how the HMC certificate is verified. For details, see doc section 'HMC certificate'"
         type: [boolean, string]
+  prometheus:
+    description: Communication with Prometheus
+    type: object
+    additionalProperties: false
+    properties:
+      port:
+        description: "Port for exporting."
+        type: integer
+      server_cert_file:
+        description: "Path name of server certificate file. Enables the use of HTTPS."
+        type: string
+      server_key_file:
+        description: "Path name of private key file."
+        type: string
+      ca_cert_file:
+        description: "Path name of CA certificates file for validating the client certificate. Enables mutual TLS by requiring a client certificate to be presented."
+        type: string
   extra_labels:
     description: "Additional Prometheus labels to be added to all metrics"
     type: array

--- a/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
+++ b/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
@@ -44,6 +44,7 @@ from ._version import __version__
 
 DEFAULT_CREDS_FILE = '/etc/zhmc-prometheus-exporter/hmccreds.yaml'
 DEFAULT_METRICS_FILE = '/etc/zhmc-prometheus-exporter/metrics.yaml'
+DEFAULT_PORT = 9291
 
 EXPORTER_LOGGER_NAME = 'zhmcexporter'
 
@@ -202,6 +203,7 @@ def zhmc_exceptions(session, hmccreds_filename):
 
 def parse_args(args):
     """Parses the CLI arguments."""
+
     parser = argparse.ArgumentParser(
         description="IBM Z HMC Exporter - a Prometheus exporter for metrics "
         "from the IBM Z HMC")
@@ -216,8 +218,9 @@ def parse_args(args):
                         "Use --help-metrics for details. "
                         "Default: {}".format(DEFAULT_METRICS_FILE))
     parser.add_argument("-p", metavar="PORT",
-                        default="9291",
-                        help="port for exporting. Default: 9291")
+                        default=None,
+                        help="port for exporting. Default: prometheus.port in "
+                        "HMC credentials file")
     parser.add_argument("--log", dest='log_dest', metavar="DEST", default=None,
                         help="enable logging and set a log destination "
                         "({dests}). Default: no logging".
@@ -283,6 +286,16 @@ metrics:
   hmc: 1.2.3.4
   userid: myuser
   password: mypassword
+
+prometheus:
+  port: 9291
+
+  # Note: Activating the following two parameters enables the use of HTTPS
+  # server_cert_file: server_cert.pem
+  # server_key_file: server_key.pem
+
+  # Note: Activating the following parameter enables the use of mutual TLS
+  # ca_cert_file: ca_certs.pem
 
 extra_labels:
   - name: pod
@@ -1802,12 +1815,70 @@ def main():
                  "Registering the collector and performing first collection")
         REGISTRY.register(coll)  # Performs a first collection
 
-        logprint(logging.INFO, PRINT_V,
-                 "Starting the HTTP server on port {}".format(args.p))
-        start_http_server(int(args.p))
+        # Get the Prometheus communication parameters
+        prom_item = yaml_creds_content.get("prometheus", {})
+        config_port = prom_item.get("port", None)
+        server_cert_file = prom_item.get("server_cert_file", None)
+        if server_cert_file:
+            prometheus_client_supports_https = sys.version_info[0:2] >= (3, 8)
+            if not prometheus_client_supports_https:
+                raise ImproperExit(
+                    "Use of https requires Python 3.8 or higher.")
+            server_key_file = prom_item.get("server_key_file", None)
+            ca_cert_file = prom_item.get("ca_cert_file", None)
+            if not server_key_file:
+                raise ImproperExit(
+                    "server_key_file not specified in HMC credentials file "
+                    "when using https.")
+            hmccreds_dir = os.path.dirname(hmccreds_filename)
+            if not os.path.isabs(server_cert_file):
+                server_cert_file = os.path.join(hmccreds_dir, server_cert_file)
+            if not os.path.isabs(server_key_file):
+                server_key_file = os.path.join(hmccreds_dir, server_key_file)
+            if ca_cert_file and not os.path.isabs(ca_cert_file):
+                ca_cert_file = os.path.join(hmccreds_dir, ca_cert_file)
+        else:  # http
+            server_cert_file = None
+            server_key_file = None
+            ca_cert_file = None
+
+        port = int(args.p or config_port or DEFAULT_PORT)
+
+        if server_cert_file:
+            logprint(logging.INFO, PRINT_V,
+                     "Starting the server with HTTPS on port {}".format(port))
+            logprint(logging.INFO, PRINT_V,
+                     "Server certificate file: {}".format(server_cert_file))
+            logprint(logging.INFO, PRINT_V,
+                     "Server private key file: {}".format(server_key_file))
+            if ca_cert_file:
+                logprint(logging.INFO, PRINT_V,
+                         "Mutual TLS: Enabled with CA certificates file: {}".
+                         format(ca_cert_file))
+            else:
+                logprint(logging.INFO, PRINT_V,
+                         "Mutual TLS: Disabled")
+        else:
+            logprint(logging.INFO, PRINT_V,
+                     "Starting the server with HTTP on port {}".format(port))
+
+        if server_cert_file:
+            try:
+                start_http_server(
+                    port=port,
+                    certfile=server_cert_file,
+                    keyfile=server_key_file,
+                    cafile=ca_cert_file,
+                    insecure_skip_verify=(ca_cert_file is None))
+            except IOError as exc:
+                raise ImproperExit(
+                    "Issues with server certificate, key, or CA certificate "
+                    "files: {}: {}".format(exc.__class__.__name__, exc))
+        else:
+            start_http_server(port=port)
 
         logprint(logging.INFO, PRINT_ALWAYS,
-                 "Exporter is up and running on port {}".format(args.p))
+                 "Exporter is up and running on port {}".format(port))
         while True:
             try:
                 time.sleep(1)


### PR DESCRIPTION
Beta release that uses the prometheus client with HTTPS support directly from its repo fork.
This release has support for Python 3.5 to 3.7 temporarily disabled, because the pip install from git repos does not support python version markers.