### PR TITLE
Dropped support for Python 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,19 +37,9 @@ jobs:
         if [[ "${{ github.event_name }}" == "schedule" || "${{ github.head_ref }}" =~ ^release_ ]]; then \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\", \"macos-latest\", \"windows-latest\" ], \
-            \"python-version\": [ \"3.5\", \"3.6\", \"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\" ], \
+            \"python-version\": [ \"3.6\", \"3.7\", \"3.8\", \"3.9\", \"3.10\", \"3.11\" ], \
             \"package_level\": [ \"minimum\", \"latest\" ], \
             \"exclude\": [ \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-latest\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
               { \
                 \"os\": \"ubuntu-latest\", \
                 \"python-version\": \"3.6\", \
@@ -62,16 +52,6 @@ jobs:
               } \
             ], \
             \"include\": [ \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
               { \
                 \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.6\", \
@@ -92,22 +72,17 @@ jobs:
             \"include\": [ \
               { \
                 \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"minimum\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
-                \"python-version\": \"3.5\", \
-                \"package_level\": \"latest\" \
-              }, \
-              { \
-                \"os\": \"ubuntu-20.04\", \
                 \"python-version\": \"3.6\", \
                 \"package_level\": \"minimum\" \
               }, \
               { \
+                \"os\": \"ubuntu-20.04\", \
+                \"python-version\": \"3.6\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
                 \"os\": \"macos-latest\", \
-                \"python-version\": \"3.5\", \
+                \"python-version\": \"3.6\", \
                 \"package_level\": \"latest\" \
               }, \
               { \
@@ -117,7 +92,7 @@ jobs:
               }, \
               { \
                 \"os\": \"windows-latest\", \
-                \"python-version\": \"3.5\", \
+                \"python-version\": \"3.6\", \
                 \"package_level\": \"latest\" \
               }, \
               { \
@@ -240,7 +215,7 @@ jobs:
         COVERALLS_SERVICE_JOB_ID: "${{ github.run_id }}"
         COVERALLS_SERVICE_NUMBER: "${{ github.workflow }}-${{ github.run_number }}"
       run: |
-        if ! [[ ${{ matrix.python-version }} =~ (3.4) ]]; then coveralls; fi
+        coveralls
     - name: Run check_reqs
       env:
         PACKAGE_LEVEL: ${{ matrix.package_level }}

--- a/.safety-policy.yml
+++ b/.safety-policy.yml
@@ -20,30 +20,16 @@ security:
     #     reason: {text}    # optional: Reason for ignoring it. Will be reported in the Safety reports
     #     expires: {date}   # optional: Date when this ignore will expire
     ignore-vulnerabilities:
-        37504:
-            reason: Fixed Twine version requires Python>=3.6 and is used there
         39611:
-            reason: PyYAML full_load method or FullLoader is not used
-        39621:
-            reason: Fixed Pylint version requires Python>=3.6 and is used there
-        40291:
-            reason: Fixed Pip version requires Python>=3.6 and is used there
-        42559:
-            reason: Fixed Pip version requires Python>=3.6 and is used there; Pip is not shipped with this package
+            reason: Fixed PyYAML versions 5.4 to 6.0.0 do not work with Cython 3, and the full_load method or FullLoader is not used
         43975:
             reason: Fixed Urllib3 versions are excluded by requests
-        45185:
-            reason: Fixed Pylint version requires Python>=3.6.2 and is used there
-        47833:
-            reason: Fixed Click version requires Python>=3.6 and is used there
         51457:
             reason: Py package is no longer being fixed (latest version 1.11.0)
         51499:
             reason: Fixed Wheel version requires Python>=3.7 and is used there; Risk is on Pypi side
         52322:
             reason: Fixed GitPython version requires Python>=3.7 and is used there
-        52365:
-            reason: Fixed Certifi version requires Python>=3.6 and is used there
         52495:
             reason: Fixed Setuptools version requires Python>=3.7 and is used there; Risk is on Pypi side
         52518:
@@ -52,8 +38,6 @@ security:
             reason: Fixed requests version 2.31.0 requires Python>=3.7 and is used there
         58910:
             reason: Fixed pygments version 2.15.0 requires Python>=3.7 and is used there
-        59956:
-            reason: Fixed certifi version 2023.07.22 requires Python>=3.6 and is used there
         60350:
             reason: Fixed GitPython version 3.1.32 requires Python>=3.7 and is used there
         60789:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,13 +10,12 @@ build>=0.5.0
 pep517>=0.9.1
 
 # Safety CI by pyup.io
-# Safety is run only on Python >=3.6
-safety>=2.2.0; python_version >= '3.6'
-dparse>=0.6.2; python_version >= '3.6'
+safety>=2.2.0
+dparse>=0.6.2
 
 # Unit test (imports into testcases):
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
-pytest>=4.3.1; python_version <= '3.6'
+pytest>=4.3.1; python_version == '3.6'
 pytest>=4.4.0; python_version >= '3.7' and python_version <= '3.9'
 pytest>=6.2.5; python_version >= '3.10'
 importlib-metadata>=0.12,<5.0.0; python_version <= '3.7'
@@ -24,9 +23,7 @@ importlib-metadata>=1.1.0; python_version >= '3.8'
 
 # packaging is used by pytest, pip-check-reqs, sphinx
 # packaging>=20.5 is needed by pip-check-reqs 2.4.3 but it requires only packaging>=16.0
-# packaging 21.0 removed support for Python <3.6
-packaging>=20.5; python_version <= '3.5'
-packaging>=21.0; python_version >= '3.6'
+packaging>=21.0
 
 # Virtualenv
 # build requires virtualenv.cli_run which was added in 20.1
@@ -52,77 +49,59 @@ pyflakes>=2.4.0; python_version >= '3.10'
 entrypoints>=0.3.0
 
 # PyLint (no imports, invoked via pylint script)
-# Pylint is not run on py27 anymore
 # Pylint requires astroid
-# Pylint 1.x / astroid 1.x supports py27 and py34/35/36
-# Pylint 2.0 / astroid 2.0 removed py27, added py37
-# Pylint 2.4 / astroid 2.3 removed py34
-# Issue #2673: Pinning Pylint to <2.7.0 is a circumvention for Pylint issue
-#   https://github.com/PyCQA/pylint/issues/4120 that appears in Pylint 2.7.0.
-#   Pylint 2.10 has fixed the issue.
-# Pylint 2.7.0 fixes safety issue 39621
-# Pylint 2.13.0 fixes safety issue 45185
-pylint>=2.5.2,<2.7.0; python_version == '3.5'
 pylint>=2.13.0,<2.14.0; python_version == '3.6'
 pylint>=2.13.0; python_version >= '3.7' and python_version <= '3.10'
 pylint>=2.15.0; python_version >= '3.11'
-astroid>=2.4.0,<2.6.0; python_version == '3.5'
-astroid>=2.11.0; python_version >= '3.6' and python_version <= '3.10'
+astroid>=2.11.0; python_version <= '3.10'
 astroid>=2.12.4; python_version >= '3.11'
-typed-ast>=1.4.0,<1.5.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
+typed-ast>=1.4.0,<1.5.0; python_version <= '3.7' and implementation_name=='cpython'
 # lazy-object-proxy is used by astroid
-lazy-object-proxy>=1.4.3; python_version >= '3.5'
-wrapt>=1.11.2; python_version >= '3.5' and python_version <= '3.10'
+lazy-object-proxy>=1.4.3
+wrapt>=1.11.2; python_version <= '3.10'
 wrapt>=1.14; python_version >= '3.11'
 # platformdirs is used by pylint starting with its 2.10
-platformdirs>=2.2.0; python_version >= '3.6'
-# isort 5.0.0 removed support for py27,py35
+platformdirs>=2.2.0
 # isort 4.2.8 fixes a pylint issue with false positive on import order of ssl on Windows
 # isort 4.3.8 fixes an issue with py310 and works on py310 (Note that isort 5.10.0 has official support for py310)
 isort>=4.3.8
 # Pylint 2.14 uses tomlkit>=0.10.1 and requires py>=3.7
 tomlkit>=0.10.1; python_version >= '3.7'
 # dill is used by pylint >=2.13
-dill>=0.2; python_version >= '3.6' and python_version <= '3.10'
+dill>=0.2; python_version <= '3.10'
 dill>=0.3.6; python_version >= '3.11'
 
 # Sphinx (no imports, invoked via sphinx-build script):
 # Keep in sync with rtd-requirements.txt
 # Sphinx 4.0.0 breaks autodocsumm and needs to be excluded
 # Sphinx <4.3.0 requires docutils <0.18 due to an incompatibility
-# Sphinx 3.0.4 fixes safety issues 45775,38330
 Sphinx>=3.5.4,!=4.0.0,<4.3.0; python_version <= '3.9'
 Sphinx>=4.2.0; python_version >= '3.10'
-docutils>=0.13.1,<0.17; python_version >= '3.5' and python_version <= '3.9'
+docutils>=0.13.1,<0.17; python_version <= '3.9'
 docutils>=0.14,<0.17; python_version == '3.10'
 docutils>=0.16,<0.17; python_version >= '3.11'
 sphinx-git>=10.1.1
-# GitPython 3.1.30 fixes safety issues 52322,52518
-GitPython>=2.1.1; python_version <= '3.6'
+GitPython>=2.1.1; python_version == '3.6'
 GitPython>=3.1.37; python_version >= '3.7'
 sphinxcontrib-fulltoc>=1.2.0
 sphinxcontrib-websupport>=1.1.2
-# Pygments 2.7.4 fixes safety issues 50885,50886
-Pygments>=2.7.4; python_version <= '3.6'
+Pygments>=2.7.4; python_version == '3.6'
 Pygments>=2.15.0; python_version >= '3.7'
 sphinx-rtd-theme>=1.0.0
 # Babel 2.7.0 fixes an ImportError for MutableMapping which starts failing on Python 3.10
-# Babel 2.9.1 fixes safety issue 42203
 Babel>=2.9.1
 
 # Twine (no imports, invoked via twine script):
-twine>=1.15.0; python_version == '3.5'
-twine>=3.0.0; python_version >= '3.6'
+twine>=3.0.0
 # readme-renderer (used by twine, uses Pygments)
 # readme-renderer 25.0 or higher is needed to address issue on Windows with py39
 readme-renderer>=25.0
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree>=2.2.0
-# pip-check-reqs is not used on Python 2.7
 # pip-check-reqs 2.3.2 is needed to have proper support for pip<21.3.
 # pip-check-reqs 2.4.0 requires Python>=3.8.
 # pip-check-reqs 2.4.3 fixes a speed issue on Python 3.11 and requires pip>=21.2.4
 # pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143
-pip-check-reqs>=2.3.2; python_version >= '3.5' and python_version <= '3.7'
+pip-check-reqs>=2.3.2; python_version <= '3.7'
 pip-check-reqs>=2.4.3,!=2.5.0; python_version >= '3.8'

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -35,7 +35,7 @@ Supported environments
 ----------------------
 
 * Operating systems: Linux, macOS, Windows
-* Python versions: 3.5 and higher
+* Python versions: 3.6 and higher
 * HMC versions: 2.11.1 and higher
 
 Quickstart

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -15,41 +15,6 @@
 # the minimum versions required in requirements.txt and dev-requirements.txt.
 
 
-# Dependencies for installation with Pip (must be installed in a separate pip call)
-#
-# Info: OS-installed package versions for some Linux distros:
-# * RHEL/CentOS 7.4.1708:
-#   Python      2.7.5     2013-05-15
-#   pip         8.1.2     2016-05-11 (epel)
-#   setuptools  0.9.8     2013-07-25
-#   wheel       0.24.0    2014-07-06 (epel)
-#   pbr         1.8.1     2015-10-07 (epel)
-# * Ubuntu 16.04.03:
-#   Python      2.7.12    2016-11-19
-#   pip         8.1.1     2016-03-17
-#   setuptools  20.7.0    2016-04-10
-#   wheel       0.29.0    2016-02-06
-#   pbr         1.8.0     2015-09-14
-# * Ubuntu 17.04:
-#   Python      2.7.12    2016-11-19
-#   pip         9.0.1     2016-11-06
-#   setuptools  33.1.1    2017-01-16
-#   wheel       0.29.0    2016-02-06
-#   pbr         1.10.0    2016-05-23
-# * Ubuntu 18.04:
-#   Python      2.7.15
-#   Python3     3.6.5
-#   pip         9.0.1     (py2+py3)
-#   setuptools  39.0.1    (py2+py3)
-#   wheel       0.30.0    (py2+py3)
-# * Ubuntu 19.04:
-#   Python      2.7.16
-#   Python3     3.7.3
-#   pip         18.1      (py2+py3)
-#   setuptools  40.8.0    (py2+py3)
-#   wheel       0.32.3    (py2+py3)
-
-
 # Base dependencies
 
 # For the base packages, we use the versions from Ubuntu 18.04 as a general
@@ -59,21 +24,13 @@
 # pip 18.0 is needed on pypy3 (py36) to support constraints like cffi!=1.11.3,>=1.8.
 # pip 18.1 supports PEP-508 URLs, so the deprecated dependency_links no longer needs to be used.
 # Pip 20.2 introduced a new resolver whose backtracking had issues that were resolved only in 21.2.2.
-# Pip 21.0 removed support for Python<=3.5
 # pip>=21.0 is needed for the cryptography package on Windows on GitHub Actions.
-# pip 19.2 fixes safety issue 38765
-# pip 21.1 fixes safety issues 42559,40291
-pip==19.3.1; python_version == '3.5'
-pip==21.2.4; python_version >= '3.6' and python_version <= '3.9'
+pip==21.2.4; python_version <= '3.9'
 pip==23.0.1; python_version >= '3.10'
-# setuptools 51.0.0 removed support for py35
 # setuptools 59.7.0 removed support for py36
-# setuptools 65.5.1 fixes safety issue 52495
-setuptools==50.3.2; python_version == '3.5'
 setuptools==59.6.0; python_version == '3.6'
 setuptools==65.5.1; python_version >= '3.7'
-# wheel 0.38.1 fixes safety issue 51499
-wheel==0.30.0; python_version <= '3.6'
+wheel==0.30.0; python_version == '3.6'
 wheel==0.38.1; python_version >= '3.7'
 
 # Direct dependencies for runtime (must be consistent with requirements.txt)
@@ -91,16 +48,14 @@ PyYAML==5.3.1
 
 # Indirect dependencies for runtime that require a version constraint (must be consistent with requirements.txt)
 
-pyrsistent==0.17.3; python_version <= '3.6'
+pyrsistent==0.17.3; python_version == '3.6'
 pyrsistent==0.18.1; python_version >= '3.7'
 
 # Indirect dependencies for runtime that are not in requirements.txt
 
 attrs==18.2.0; python_version <= '3.9'
 attrs==19.2.0; python_version >= '3.10'
-# certifi 2022.12.07 fixes safety issue 52365
-certifi==2019.9.11; python_version <= '3.5'
-certifi==2023.07.22; python_version >= '3.6'
+certifi==2023.07.22
 charset-normalizer==2.0.4
 decorator==4.0.11
 docopt==0.6.2
@@ -109,7 +64,7 @@ immutable-views==0.6.0
 MarkupSafe==1.1.0
 pytz==2016.10; python_version <= '3.9'
 pytz==2019.1; python_version >= '3.10'
-requests==2.25.0; python_version <= '3.6'
+requests==2.25.0; python_version == '3.6'
 requests==2.31.0; python_version >= '3.7'
 stomp.py==4.1.23
 typing-extensions==3.10.0  # Used in some combinations of Python version and package level
@@ -124,23 +79,22 @@ pep517==0.9.1
 
 # Safety CI by pyup.io
 # Safety is run only on Python >=3.6
-safety==2.2.0; python_version >= '3.6'
-dparse==0.6.2; python_version >= '3.6'
+safety==2.2.0
+dparse==0.6.2
 
 # Unit test (imports into testcases):
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels
-pytest==4.3.1; python_version <= '3.6'
+pytest==4.3.1; python_version == '3.6'
 pytest==4.4.0; python_version >= '3.7' and python_version <= '3.9'
 pytest==6.2.5; python_version >= '3.10'
 # pluggy (used by pytest)
 # Pluggy 0.12.0 has a bug causing pytest plugins to fail loading on py38
-pluggy==0.7.1; python_version <= '3.6'
+pluggy==0.7.1; python_version == '3.6'
 pluggy==0.13.0; python_version >= '3.7'
 importlib-metadata==0.22; python_version <= '3.7'
 importlib-metadata==1.1.0; python_version >= '3.8'
 
-packaging==20.5; python_version <= '3.5'
-packaging==21.0; python_version >= '3.6'
+packaging==21.0
 
 # Virtualenv
 virtualenv==20.1.0
@@ -161,46 +115,43 @@ pyflakes==2.4.0; python_version >= '3.10'
 entrypoints==0.3.0
 
 # PyLint (no imports, invoked via pylint script):
-pylint==2.5.2; python_version == '3.5'
-pylint==2.13.0; python_version >= '3.6' and python_version <= '3.10'
+pylint==2.13.0; python_version <= '3.10'
 pylint==2.15.0; python_version >= '3.11'
-astroid==2.4.0; python_version == '3.5'
-astroid==2.11.0; python_version >= '3.6' and python_version <= '3.10'
+astroid==2.11.0; python_version <= '3.10'
 astroid==2.12.4; python_version >= '3.11'
-typed-ast==1.4.0; python_version >= '3.6' and python_version < '3.8' and implementation_name=='cpython'
-lazy-object-proxy==1.4.3; python_version >= '3.5'
-wrapt==1.12; python_version >= '3.5' and python_version <= '3.10'
+typed-ast==1.4.0; python_version <= '3.7' and implementation_name=='cpython'
+lazy-object-proxy==1.4.3
+wrapt==1.12; python_version <= '3.10'
 wrapt==1.14; python_version >= '3.11'
-platformdirs==2.2.0; python_version >= '3.6'
+platformdirs==2.2.0
 isort==4.3.8
 tomlkit==0.10.1; python_version >= '3.7'
-dill==0.2; python_version >= '3.6' and python_version <= '3.10'
+dill==0.2; python_version <= '3.10'
 dill==0.3.6; python_version >= '3.11'
 
 # Sphinx (no imports, invoked via sphinx-build script):
 Sphinx==3.5.4; python_version <= '3.9'
 Sphinx==4.2.0; python_version >= '3.10'
-docutils==0.13.1; python_version >= '3.5' and python_version <= '3.9'
+docutils==0.13.1; python_version <= '3.9'
 docutils==0.14; python_version == '3.10'
 docutils==0.16; python_version >= '3.11'
 sphinx-git==10.1.1
-GitPython==2.1.1; python_version <= '3.6'
+GitPython==2.1.1; python_version == '3.6'
 GitPython==3.1.37; python_version >= '3.7'
 sphinxcontrib-websupport==1.1.2
-Pygments==2.7.4; python_version <= '3.6'
+Pygments==2.7.4; python_version == '3.6'
 Pygments==2.15.0; python_version >= '3.7'
 sphinx-rtd-theme==1.0.0
 Babel==2.9.1
 
 # Twine (no imports, invoked via twine script):
 # readme-renderer (used by twine, uses Pygments)
-twine==1.15.0; python_version == '3.5'
-twine==3.0.0; python_version >= '3.6'
+twine==3.0.0
 readme-renderer==25.0
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree==2.2.0
-pip-check-reqs==2.3.2; python_version >= '3.5' and python_version <= '3.7'
+pip-check-reqs==2.3.2; python_version <= '3.7'
 pip-check-reqs==2.4.3; python_version >= '3.8'
 
 # Indirect dependencies for development that require a version constraint (must be consistent with dev-requirements.txt)
@@ -216,9 +167,8 @@ bleach==3.3.0
 chardet==3.0.4  # used with minimum package levels
 colorama==0.4.5; sys_platform == "win32"
 contextlib2==0.6.0
-gitdb2==2.0.0; python_version <= '3.6'
-gitdb==4.0.1; python_version == '3.5'
-gitdb==4.0.8; python_version >= '3.6'
+gitdb2==2.0.0; python_version == '3.6'
+gitdb==4.0.8
 html5lib==1.0.1  # used with minimum package levels
 imagesize==0.7.1
 iniconfig==1.1.1; python_version >= "3.6"  # used by pytest since its 6.0.0 which requires py36

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,25 +17,21 @@ six>=1.14.0; python_version <= '3.9'
 six>=1.16.0; python_version >= '3.10'
 Jinja2>=2.11.3
 
-# PyYAML pulled in by zhmcclient examples
-# PyYAML 5.3.1 addressed issue 38100 reported by safety
-# PyYAML is also used by dparse and python-coveralls
-# PyYAML 5.4 has removed support for py35
-# PyYAML 5.3 has wheel archives for Python 2.7, 3.5 - 3.9
-# PyYAML 5.4 has wheel archives for Python 2.7, 3.6 - 3.9
-# PyYAML 6.0 has wheel archives for Python 3.6 - 3.11
-# PyYAML 5.4 and 6.0.0 fails install since Cython 3 was released, see issue
-#   https://github.com/yaml/pyyaml/issues/724.
-PyYAML>=5.3.1; python_version == '3.5'
+# PyYAML 5.3.x has wheel archives for Python 2.7, 3.5 - 3.9
+# PyYAML 5.4.x has wheel archives for Python 2.7, 3.6 - 3.9
+# PyYAML 6.0.0 has wheel archives for Python 3.6 - 3.11
+# PyYAML 6.0.1 has wheel archives for Python 3.6 - 3.12
+# PyYAML versions without wheel archives fail install since Cython 3 was
+#   released, see https://github.com/yaml/pyyaml/issues/724.
 PyYAML>=5.3.1,!=5.4.0,!=5.4.1; python_version >= '3.6' and python_version <= '3.11'
 PyYAML>=5.3.1,!=5.4.0,!=5.4.1,!=6.0.0; python_version >= '3.12'
 
 # Indirect dependencies for runtime (must be consistent with minimum-constraints.txt)
 
-# pyrsistent is pulled in by jsonschema.
+# pyrsistent is used by jsonschema 3.x (no longer by jsonschema 4.x)
 # Before its version 0.17.0, pyrsistent did not or not correctly declare its
-# required Python versions in the package metadata.
+#   required Python versions in the package metadata.
 # pyrsistent 0.15.0 fixes import errors on Python>=3.10, but only 0.18.1 has
-# Python 3.10 support (accordong to the change log).
-pyrsistent>=0.17.3; python_version <= '3.6'
+#   Python 3.10 support (accordong to the change log).
+pyrsistent>=0.17.3; python_version == '3.6'
 pyrsistent>=0.18.1; python_version >= '3.7'

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setuptools.setup(
 
     # Keep these Python versions in sync with:
     # - Section "Supported environments" in docs/intro.rst
-    python_requires='>=3.5',
+    python_requires='>=3.6',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
@@ -130,7 +130,6 @@ setuptools.setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
+++ b/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
@@ -31,7 +31,6 @@ import logging.handlers
 from contextlib import contextmanager
 
 import jinja2
-import six
 import urllib3
 import yaml
 import jsonschema
@@ -548,7 +547,7 @@ def create_session(cred_dict, hmccreds_filename):
              "HMC userid: {}".format(cred_dict["userid"]))
 
     verify_cert = cred_dict.get("verify_cert", True)
-    if isinstance(verify_cert, six.string_types):
+    if isinstance(verify_cert, str):
         if not os.path.isabs(verify_cert):
             verify_cert = os.path.join(
                 os.path.dirname(hmccreds_filename), verify_cert)


### PR DESCRIPTION
The special name of the branch of this PR causes the full set of Python versions to be tested against, to make sure everything works. The normal set of Python versions after this change is smaller than before.

For details, see the commit message.