### PR TITLE
Dropped support for Python 3.5 - part 2

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,10 @@
 # of appearance.
 #
 
+# Six
+six>=1.14.0; python_version <= '3.9'
+six>=1.16.0; python_version >= '3.10'
+
 # PEP517 package builder, used in Makefile
 build>=0.5.0
 # build up to version 0.9 requires pep517>=0.9.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,6 @@ prometheus-client>=0.9.0
 urllib3>=1.25.9; python_version <= '3.9'
 urllib3>=1.26.5; python_version >= '3.10'
 jsonschema>=3.2.0
-six>=1.14.0; python_version <= '3.9'
-six>=1.16.0; python_version >= '3.10'
 Jinja2>=2.11.3
 
 # PyYAML 5.3.x has wheel archives for Python 2.7, 3.5 - 3.9


### PR DESCRIPTION
This PR moves the six package from requirenments.txt to dev-requirements.txt. This was intended to be done in the earlier commit on this topic, but was forgotten.