### PR TITLE
1.4: Fixed ruamel.yaml issue on Python 3.6 by pinning to <0.17.22

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,6 +13,8 @@ pep517>=0.9.1
 # Safety is run only on Python >=3.6
 safety>=2.2.0; python_version >= '3.6'
 dparse>=0.6.2; python_version >= '3.6'
+ruamel.yaml>=0.17.21,<0.17.22; python_version == '3.6'
+ruamel.yaml>=0.17.21; python_version >= '3.7'
 
 # Unit test (imports into testcases):
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -126,6 +126,7 @@ pep517==0.9.1
 # Safety is run only on Python >=3.6
 safety==2.2.0; python_version >= '3.6'
 dparse==0.6.2; python_version >= '3.6'
+ruamel.yaml==0.17.21; python_version >= '3.6'
 
 # Unit test (imports into testcases):
 # pytest 4.3.1 solves an issue on Python 3 with minimum package levels


### PR DESCRIPTION
Rolls back PR #402 into 1.4.2.