### PR TITLE
Release 1.5.0b1

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,19 +17,21 @@ Change log
 ----------
 
 
-Version 1.5.0.dev1
-^^^^^^^^^^^^^^^^^^
+Version 1.5.0.b1
+^^^^^^^^^^^^^^^^
 
-This version contains all fixes up to version 1.4.x.
+This is a beta version that supports only Python 3.8 and higher, because
+it pulls in the prometheus-client package from its repo master branch.
+The final 1.5.0 version will again support Python >=3.6.
 
-Released: not yet
+This version contains all fixes up to version 1.4.2.
+
+Released: 2023-11-09
 
 **Incompatible changes:**
 
 * Installation of this package using "setup.py" is no longer supported.
   Use "pip" instead.
-
-**Deprecations:**
 
 **Bug fixes:**
 
@@ -95,14 +97,6 @@ Released: not yet
 
 * Added support for HTTPS and mutual TLS (mTLS) by adding a new optional section
   'prometheus' to the HMC credentials file. (issue #347)
-
-**Cleanup:**
-
-**Known issues:**
-
-* See `list of open issues`_.
-
-.. _`list of open issues`: https://github.com/zhmcclient/zhmc-prometheus-exporter/issues
 
 
 Version 1.4.0

--- a/zhmc_prometheus_exporter/_version.py
+++ b/zhmc_prometheus_exporter/_version.py
@@ -25,4 +25,4 @@ __all__ = ['__version__']
 #:
 #: * "M.N.P.dev1": A not yet released version M.N.P
 #: * "M.N.P": A released version M.N.P
-__version__ = '1.5.0.dev1'
+__version__ = '1.5.0b1'


### PR DESCRIPTION
This is a beta version that supports only Python 3.8 and higher, because it pulls in the prometheus-client package from its repo master branch. (The final 1.5.0 version will again support Python >=3.6).

No review needed.