### PR TITLE
Release 1.5.0b2

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -17,7 +17,7 @@ Change log
 ----------
 
 
-Version 1.5.0.b1
+Version 1.5.0.b2
 ^^^^^^^^^^^^^^^^
 
 This is a beta version that supports only Python 3.8 and higher, because

--- a/zhmc_prometheus_exporter/_version.py
+++ b/zhmc_prometheus_exporter/_version.py
@@ -25,4 +25,4 @@ __all__ = ['__version__']
 #:
 #: * "M.N.P.dev1": A not yet released version M.N.P
 #: * "M.N.P": A released version M.N.P
-__version__ = '1.5.0b1'
+__version__ = '1.5.0b2'


### PR DESCRIPTION
Since 1.5.0b1 was already released via the repo back in august, this release needs to be named 1.5.0b2.