### PR TITLE
Added exception handling for HTTP; Broadened exception handling for HTTPS

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -65,6 +65,9 @@ Released: not yet
 
 * Test: Circumvented a pip-check-reqs issue by excluding its version 2.5.0.
 
+* Added handling of exceptions raised by the built-in HTTP server during
+  its startup, for the HTTP case. (related to issue #397)
+
 **Enhancements:**
 
 * Added support for Python 3.12. Had to increase the minimum versions of

--- a/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
+++ b/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
@@ -1868,12 +1868,20 @@ def main():
                     keyfile=server_key_file,
                     client_cafile=ca_cert_file,
                     client_auth_required=(ca_cert_file is not None))
+            # pylint_ disable=broad-exception
+            except Exception as exc:
+                # We catch Exception for now in order to investigate the
+                # issue that with ssl.SSLEOFError being raised occasionally.
+                raise ImproperExit(
+                    "Cannot start HTTPS server: {}: {}".
+                    format(exc.__class__.__name__, exc))
+        else:
+            try:
+                start_http_server(port=port)
             except IOError as exc:
                 raise ImproperExit(
-                    "Issues with server certificate, key, or CA certificate "
-                    "files: {}: {}".format(exc.__class__.__name__, exc))
-        else:
-            start_http_server(port=port)
+                    "Cannot start HTTP server: {}: {}".
+                    format(exc.__class__.__name__, exc))
 
         logprint(logging.INFO, PRINT_ALWAYS,
                  "Exporter is up and running on port {}".format(port))


### PR DESCRIPTION
For details, see the commit message.

Note that this PR does not address the problem reported in issue #397 because I think that error is raised by the HTTPS thread after `start_http_server()` has already returned.