### PR TITLE
Fixed warning about ignoring label 'adapter/port'

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -45,6 +45,10 @@ will also work with the prior version of the file (but not vice versa).
 * Docs: Added missing 'se_version' variable to description of 'export-condition'
   and 'fetch-condition' in the Usage section. (part of issue #459)
 
+* Fixed warning about ignoring label 'adapter/port' on metric group
+  'partition-attached-network-interface' due to error in rendering the Jinja2
+  expression for a label value. (issue #450)
+
 **Enhancements:**
 
 * Split safety runs into one against all requirements that may fail and one

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -369,7 +369,7 @@ def setup_metrics_context():
          "metric-groups": ["dpm-system-usage-overview"]})
     resources = {}
     resources["cpc-resource"] = [client.cpcs.find(name='cpc_1')]
-    return context, resources
+    return session, context, resources
 
 
 def teardown_metrics_context(context):
@@ -384,7 +384,7 @@ class TestMetrics(unittest.TestCase):
         # pylint: disable=no-self-use
         """Tests retrieve_metrics()"""
 
-        context, _ = setup_metrics_context()
+        _, context, _ = setup_metrics_context()
 
         metrics_object = zhmc_prometheus_exporter.retrieve_metrics(context)
 
@@ -449,13 +449,13 @@ class TestMetrics(unittest.TestCase):
         se_versions_by_cpc = {'cpc_1': '2.15.0'}
         se_features_by_cpc = {'cpc_1': []}
 
-        context, resources = setup_metrics_context()
+        session, context, resources = setup_metrics_context()
         metrics_object = zhmc_prometheus_exporter.retrieve_metrics(context)
 
         families = zhmc_prometheus_exporter.build_family_objects(
             metrics_object, yaml_metric_groups, yaml_metrics, 'file',
             extra_labels, hmc_version, hmc_api_version, hmc_features,
-            se_versions_by_cpc, se_features_by_cpc)
+            se_versions_by_cpc, se_features_by_cpc, session)
 
         assert len(families) == 1
         assert "zhmc_pre_processor_usage" in families
@@ -477,7 +477,7 @@ class TestMetrics(unittest.TestCase):
         families = zhmc_prometheus_exporter.build_family_objects_res(
             resources, yaml_metric_groups, yaml_metrics, 'file',
             extra_labels, hmc_version, hmc_api_version, hmc_features,
-            se_versions_by_cpc, se_features_by_cpc)
+            se_versions_by_cpc, se_features_by_cpc, session)
 
         assert len(families) == 1
         assert "zhmc_foo_name" in families


### PR DESCRIPTION
For details, see the commit message.

Tested the change on the HMC of A224. However, I could not reproduce the new log message when adding NICs.

Also, in tests on dal12z1.CPCB where the problem originally was observed on partition dal2-qz2-sr2-rk070-m09 it could not be reproduced. We ran the old exporter and an exporter with the code from this PR in parallel for 2 days, but creating NICs did not trigger the situation.

Even though we don't understand yet what triggers the situation, the change in this PR handles the situation definitely better than before, soI think we should go ahead with the PR.