### PR TITLE
Added new z16 partition power metrics

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -90,6 +90,22 @@ will also work with the prior version of the file (but not vice versa).
 * Added support for environment variables 'TESTCASES' for specifying testcases
   for the unit test, and 'TESTOPTS' for specifying pytest options. (issue #461)
 
+* Added support for the new partition power consumption metrics in z16
+  (issue #448):
+
+  In metric group 'zcpc-environmentals-and-power':
+
+  - 'zhmc_cpc_total_partition_power_watt' - Total power consumption of all
+    partitions of the CPC
+  - 'zhmc_cpc_total_infrastructure_power_watt' - Total power consumption of all
+    infrastructure components of the CPC
+  - 'zhmc_cpc_total_unassigned_power_watt' - Total power consumption of all
+    unassigned components of the CPC
+
+  In metric group 'logical-partition-usage':
+
+  - 'zhmc_partition_power_watt' - Power consumption of the partition
+
 **Cleanup:**
 
 * Increased versions of GitHub Actions plugins to increase node.js runtime

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -482,6 +482,9 @@ zhmc_cpc_heat_load_total_btu_per_hour                   C+D   G     Total heat l
 zhmc_cpc_heat_load_forced_air_btu_per_hour              C+D   G     Heat load of the CPC covered by forced-air
 zhmc_cpc_heat_load_water_btu_per_hour                   C+D   G     Heat load of the CPC covered by water
 zhmc_cpc_exhaust_temperature_celsius                    C+D   G     Exhaust temperature of the CPC
+zhmc_cpc_total_partition_power_watt                     C     G     Total power consumption of all partitions; only with SE feature environmental-metrics
+zhmc_cpc_total_infrastructure_power_watt                C+D   G     Total power consumption of all infrastructure comp.; only with SE feature environmental-metrics
+zhmc_cpc_total_unassigned_power_watt                    C+D   G     Total power consumption of all unassigned comp.; only with SE feature environmental-metrics
 zhmc_cpc_power_cord1_phase_a_watt                       C+D   G     Power in Phase A of line cord 1 - 0 if not available
 zhmc_cpc_power_cord1_phase_b_watt                       C+D   G     Power in Phase B of line cord 1 - 0 if not available
 zhmc_cpc_power_cord1_phase_c_watt                       C+D   G     Power in Phase C of line cord 1 - 0 if not available
@@ -524,6 +527,7 @@ zhmc_partition_crypto_adapter_usage_ratio               D     G     Usage ratio 
 zhmc_partition_network_adapter_usage_ratio              D     G     Usage ratio of all network adapters of the partition
 zhmc_partition_storage_adapter_usage_ratio              D     G     Usage ratio of all storage adapters of the partition
 zhmc_partition_zvm_paging_rate_pages_per_second         C     G     z/VM paging rate in pages/sec
+zhmc_partition_power_watt                               C     G     Power consumption of the partition; only with SE feature environmental-metrics
 zhmc_partition_processor_mode_int                       C+D   G     Allocation mode for processors as an integer (0=shared, 1=dedicated); since HMC 2.15
 zhmc_partition_threads_per_processor_ratio              D     G     Number of threads per processor used by OS
 zhmc_partition_defined_capacity_msu_per_hour            C     G     Defined capacity expressed in terms of MSU per hour

--- a/examples/metrics.yaml
+++ b/examples/metrics.yaml
@@ -337,6 +337,11 @@ metrics:
       percent: false
       exporter_name: zvm_paging_rate_pages_per_second
       exporter_desc: z/VM paging rate in pages/sec
+    power-consumption:
+      if: "'environmental-metrics' in se_features"
+      percent: false
+      exporter_name: power_watt
+      exporter_desc: Power consumption of the partition
 
   channel-usage:
     channel-usage:
@@ -1140,6 +1145,21 @@ metrics:
       percent: false
       exporter_name: exhaust_temperature_celsius
       exporter_desc: Exhaust temperature of the CPC
+    total-partition-power-consumption-watts:
+      if: "'environmental-metrics' in se_features"  # and only in classic mode (no need to put that into condition)
+      percent: false
+      exporter_name: total_partition_power_watt
+      exporter_desc: Total power consumption of all partitions of the CPC (CPU, memory, I/O adapters)
+    total-infrastructure-power-consumption-watts:
+      if: "'environmental-metrics' in se_features"
+      percent: false
+      exporter_name: total_infrastructure_power_watt
+      exporter_desc: Total power consumption of all infrastructure components of the CPC (TOR switches, SE/HMAs, PDUs)
+    total-unassigned-power-consumption-watts:
+      if: "'environmental-metrics' in se_features"
+      percent: false
+      exporter_name: total_unassigned_power_watt
+      exporter_desc: Total power consumption of all unassigned components of the CPC (CPU, memory, I/O adapters)
 
   environmental-power-status:
     linecord-one-power-phase-A:


### PR DESCRIPTION
For details, see the commit message.

Particular review points:
* Exported names of the new metrics
* Exported descriptions of the new metrics

End2end tests:
* Ran the exporter against the HMC of A224 to verify the new metrics are exported for A224 but not for T224 and M224M.
* Did not run the exporter against a z16 in classic mode