### PR TITLE
Fixed name of 'power-consumption-watts' metric in LPAR usage MG

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -61,6 +61,9 @@ will also work with the prior version of the file (but not vice versa).
 
 * Fixed traceback when HMC credentials file does not exist.
 
+* Fixed the name of the 'power-consumption-watts' metric in the
+  'logical-partition-usage' HMC metric group. (issue #475)
+
 **Enhancements:**
 
 * Increased zhmcclient version to 1.14.0 to pick up fixes and improvements.

--- a/examples/metrics.yaml
+++ b/examples/metrics.yaml
@@ -337,7 +337,7 @@ metrics:
       percent: false
       exporter_name: zvm_paging_rate_pages_per_second
       exporter_desc: z/VM paging rate in pages/sec
-    power-consumption:
+    power-consumption-watts:
       if: "'environmental-metrics' in se_features"
       percent: false
       exporter_name: power_watt


### PR DESCRIPTION
For details, see the commit message.

Tested on A65.