### PR TITLE
1.6: Dev: Added missing development requirement for 'filelock' package

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -36,6 +36,8 @@ Released: not yet
 
 * Docs: Fixed README badges by converting it to Markdown. (issue #507)
 
+* Dev: Added missing development requirement for 'filelock' package.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -129,6 +129,8 @@ bleach==3.3.0
 chardet==3.0.4  # used with minimum package levels
 colorama==0.4.5; sys_platform == "win32"
 contextlib2==0.6.0
+filelock==3.4.1; python_version == '3.6'
+filelock==3.12.2; python_version >= '3.7'
 gitdb2==2.0.0; python_version == '3.6'
 gitdb==4.0.8
 html5lib==1.0.1  # used with minimum package levels


### PR DESCRIPTION
Rolls back PR #530 into 1.6.1.