### PR TITLE
1.6: Fixed AttributeError when using 'storage_groups' on 'Client' object

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -38,6 +38,8 @@ Released: not yet
 
 * Dev: Added missing development requirement for 'filelock' package.
 
+* Fixed AttributeError when using 'storage_groups' on 'Client' object.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
+++ b/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
@@ -1091,7 +1091,13 @@ def uri_to_resource(client, uri2resource, uri):
         m = re.match(r'(/api/storage-groups/[a-f0-9\-]+)$', uri)
         if m is not None:
             # Resource URI is for a storage group
-            stogrp = client.storage_groups.resource_object(uri)
+            console = client.consoles.console
+            stogrp = console.storage_groups.resource_object(uri)
+            # Get the CPC via 'uri2resource()' because that avoids the
+            # "Get CPC Properties" operation that is performed when getting it
+            # via the 'cpc' property on the storage group object.
+            cpc_uri = stogrp.get_property('cpc-uri')
+            cpc = uri_to_resource(client, uri2resource, cpc_uri)
             logprint(logging.INFO, PRINT_V,
                      "Adding storage group {}.{} after exporter start for "
                      "fast lookup".format(cpc.name, stogrp.name))


### PR DESCRIPTION
Rolls back PR #540 into 1.6.1.