### PR TITLE
Minimized symbols when importing zhmc_prometheus_exporter

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -57,6 +57,8 @@ Released: not yet
 * Dev: Removed support for editable installs, because pip 25 will disable that.
   (issue #546)
 
+* Minimized symbols when importing zhmc_prometheus_exporter.
+
 **Known issues:**
 
 * See `list of open issues`_.

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -30,7 +30,7 @@ import zhmcclient
 import zhmcclient_mock
 import prometheus_client
 
-import zhmc_prometheus_exporter
+from zhmc_prometheus_exporter import zhmc_prometheus_exporter
 
 
 class TestParseArgs(unittest.TestCase):
@@ -46,7 +46,7 @@ class TestParseArgs(unittest.TestCase):
 
     def test_default_args(self):
         """Tests for all defaults."""
-        args = zhmc_prometheus_exporter.zhmc_prometheus_exporter.parse_args([])
+        args = zhmc_prometheus_exporter.parse_args([])
         self.assertEqual(args.p, None)
         self.assertEqual(args.c, "/etc/zhmc-prometheus-exporter/hmccreds.yaml")
         self.assertEqual(args.m, "/etc/zhmc-prometheus-exporter/metrics.yaml")

--- a/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
+++ b/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
@@ -43,6 +43,8 @@ from prometheus_client.core import GaugeMetricFamily, CounterMetricFamily, \
 
 from ._version import __version__
 
+__all__ = []
+
 DEFAULT_CREDS_FILE = '/etc/zhmc-prometheus-exporter/hmccreds.yaml'
 DEFAULT_METRICS_FILE = '/etc/zhmc-prometheus-exporter/metrics.yaml'
 DEFAULT_PORT = 9291


### PR DESCRIPTION
No review needed.