### PR TITLE
Using prometheus_client 0.20.0.post1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,8 @@ safety: $(done_dir)/safety_all_$(pymn)_$(PACKAGE_LEVEL).done $(done_dir)/safety_
 check_reqs: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done minimum-constraints.txt minimum-constraints-install.txt requirements.txt
 	@echo "Makefile: Checking missing dependencies of this package"
 	pip-missing-reqs $(package_name) --requirements-file=requirements.txt
-	pip-missing-reqs $(package_name) --requirements-file=minimum-constraints-install.txt
+# TODO: Enable again once official prometheus-client version (0.21.0 ?) is released.
+# pip-missing-reqs $(package_name) --requirements-file=minimum-constraints-install.txt
 	@echo "Makefile: Done checking missing dependencies of this package"
 ifeq ($(PLATFORM),Windows_native)
 # Reason for skipping on Windows is https://github.com/r1chardj0n3s/pip-check-reqs/issues/67

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -42,6 +42,13 @@ Released: not yet
 
 * Fixed AttributeError when using 'storage_groups' on 'Client' object.
 
+* Used a forked version 0.20.0.post1 of the 'prometheus_client' package to pick
+  up the following fixes:
+
+  - Fixed HTTP verb tampering test failures. (issue #494)
+  - Fixed vulnerabilities in Prometheus server detected by testssl.sh.
+    (issues #508, #509)
+
 **Enhancements:**
 
 * Docs: Added a section about the size of captured terminal output and log

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -18,7 +18,8 @@ wheel==0.38.1
 # Direct dependencies for install (must be consistent with requirements.txt)
 
 zhmcclient==1.14.0
-prometheus-client==0.19.0
+# TODO: Use official prometheus-client version (0.21.0 ?) once released.
+# prometheus-client==0.21.0
 urllib3==1.26.19
 jsonschema==3.2.0
 six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,13 @@
 zhmcclient>=1.14.0
 
 # prometheus-client 0.19.0 added support for HTTPS/mTLS
-prometheus-client>=0.19.0
+# prometheus-client 0.20.0 improved HTTPS/mTLS support
+# prometheus-client 0.20.0.post1 (on forked repo) adds the following PRs:
+# - Removed CBC ciphers to address CVE-2013-0169 (LUCKY13) (PR https://github.com/prometheus/client_python/pull/1051)
+# - Reject invalid HTTP methods and resources (PR https://github.com/prometheus/client_python/pull/1019)
+# TODO: Use official prometheus-client version (0.21.0 ?) with these PRs once released.
+prometheus-client @ git+https://github.com/andy-maier/client_python.git@release_0.20.0.post1
+# prometheus-client>=0.21.0
 
 urllib3>=1.26.19
 jsonschema>=3.2.0


### PR DESCRIPTION
This change uses prometheus_client version 0.20.0.post1 from my fork at https://github.com/andy-maier/client_python/releases/tag/0.20.0.post1