### PR TITLE
1.6: Updated actions github-script to v7 to address node version warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,7 +194,7 @@ jobs:
     steps:
     - name: Set run type (normal, scheduled, release)
       id: set-run-type
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         result-encoding: string
         script: |


### PR DESCRIPTION
Rolls back PR #554 into 1.6.1.