### PR TITLE
1.6.1.post1: Using prometheus_client 0.20.0.post1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -260,7 +260,8 @@ check_reqs: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done minimum-constraint
 ifeq ($(run_check_reqs_install),true)
 	@echo "Makefile: Checking missing dependencies of this package"
 	pip-missing-reqs $(package_name) --requirements-file=requirements.txt
-	pip-missing-reqs $(package_name) --requirements-file=minimum-constraints-install.txt
+# TODO: Enable again once official prometheus-client version (0.21.0 ?) is released.
+# pip-missing-reqs $(package_name) --requirements-file=minimum-constraints-install.txt
 	@echo "Makefile: Done checking missing dependencies of this package"
 endif
 ifeq ($(PLATFORM),Windows_native)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,6 +28,13 @@ Released: not yet
 
 **Bug fixes:**
 
+* Used a forked version 0.20.0.post1 of the 'prometheus_client' package to pick
+  up the following fixes:
+
+  - Fixed HTTP verb tampering test failures. (issue #494)
+  - Fixed vulnerabilities in Prometheus server detected by testssl.sh.
+    (issues #508, #509)
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -34,10 +34,8 @@ wheel==0.38.1; python_version >= '3.7'
 # Direct dependencies for install (must be consistent with requirements.txt)
 
 zhmcclient==1.14.0
-
-prometheus-client==0.17.1; python_version <= '3.7'
-prometheus-client==0.19.0; python_version >= '3.8'
-
+# TODO: Use official prometheus-client version (0.21.0 ?) once released.
+# prometheus-client==0.21.0
 urllib3==1.26.19
 jsonschema==3.2.0
 six==1.14.0; python_version <= '3.9'

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,10 +9,14 @@
 # zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
 zhmcclient>=1.14.0
 
-# prometheus-client 0.18.0 has removed support for py36,37
-# prometheus-client 0.19.0 added support for HTTPS/mTLS, but requires py38
-prometheus-client>=0.17.1; python_version <= '3.7'
-prometheus-client>=0.19.0; python_version >= '3.8'
+# prometheus-client 0.19.0 added support for HTTPS/mTLS
+# prometheus-client 0.20.0 improved HTTPS/mTLS support
+# prometheus-client 0.20.0.post1 (on forked repo) adds the following PRs:
+# - Removed CBC ciphers to address CVE-2013-0169 (LUCKY13) (PR https://github.com/prometheus/client_python/pull/1051)
+# - Reject invalid HTTP methods and resources (PR https://github.com/prometheus/client_python/pull/1019)
+# TODO: Use official prometheus-client version (0.21.0 ?) with these PRs once released.
+prometheus-client @ git+https://github.com/andy-maier/client_python.git@release_0.20.0.post1
+# prometheus-client>=0.21.0
 
 urllib3>=1.26.19
 jsonschema>=3.2.0


### PR DESCRIPTION
Rolls back PR #551 into 1.6.1.post1.
No review needed.