### PR TITLE
Fixed RTD build requirements by adding base-requirements.txt

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,4 +21,6 @@ sphinx:
 # Python requirements required to build the docs
 python:
    install:
+     - requirements: requirements.txt
+     - requirements: base-requirements.txt
      - requirements: dev-requirements.txt


### PR DESCRIPTION
No review needed.
For the RTD build failure this fixes, see https://readthedocs.org/projects/zhmc-prometheus-exporter/builds/25209277/
No rollback to 1.7 needed, since this is related to the transition to setuptools_scm.