### PR TITLE
Increased minimum version of zhmcclient to 1.17.0

### DIFF
--- a/.safety-policy-install.yml
+++ b/.safety-policy-install.yml
@@ -30,12 +30,6 @@ security:
             reason: Fixed PyYAML versions 5.4 to 6.0.0 do not work with Cython 3, and the full_load method or FullLoader is not used
         67599:
             reason: There is no fixed pip version
-        67884:
-            # TODO: Adjust once we remove stomp-py pinning
-            reason: Fixed stomp-py version 8.1.1 conflicts with our pinning of stomp-py to <7.0.0
-        67894:
-            # TODO: Adjust once we remove stomp-py pinning
-            reason: Fixed stomp-py version 8.1.1 conflicts with our pinning of stomp-py to <7.0.0
         70612:
             reason: Disputed issue in Jinja2 version 3.1.3 - No known fix
 

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -19,7 +19,7 @@ wheel==0.38.1
 
 # Direct dependencies for install (must be consistent with requirements.txt)
 
-zhmcclient==1.14.0
+zhmcclient==1.17.0
 # TODO: Use official prometheus-client version (0.21.0 ?) once released.
 # prometheus-client==0.21.0
 urllib3==1.26.19
@@ -48,6 +48,6 @@ immutable-views==0.6.0
 MarkupSafe==2.0.0
 pytz==2019.1
 requests==2.32.2
-stomp.py==4.1.23
+stomp-py==8.1.1
 typing-extensions==4.7.1
 zipp==0.5.2  # Used in some combinations of Python version and package level

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 # Direct dependencies for install (must be consistent with minimum-constraints-install.txt)
 
 # zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
-zhmcclient>=1.14.0
+zhmcclient>=1.17.0
 
 # prometheus-client 0.19.0 added support for HTTPS/mTLS
 # prometheus-client 0.20.0 improved HTTPS/mTLS support


### PR DESCRIPTION
No review needed.
Cannot be rolled back to 1.7 due to Python>=3.8 requirement.