### PR TITLE
1.7: Addressed safety issues up to 2024-07-21; Added new safety req psutil

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -30,6 +30,7 @@ pydantic>=1.10.13
 typer>=0.12.0
 typer-cli>=0.12.0
 typer-slim>=0.12.0
+psutil>=6.0.0
 
 # Unit test (imports into testcases):
 pytest>=6.2.5

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,6 +28,8 @@ Released: not yet
 
 **Bug fixes:**
 
+* Addressed safety issues up to 2024-08-13.
+
 * Test: Fixed coverage reporting (locally and on coveralls.io).
 
 **Enhancements:**

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -36,7 +36,7 @@ pyrsistent==0.18.1
 # All other indirect dependencies for install that are not in requirements.txt
 
 attrs==19.2.0
-certifi==2023.07.22
+certifi==2024.07.04
 charset-normalizer==2.0.4
 decorator==4.0.11
 docopt==0.6.2
@@ -49,4 +49,4 @@ requests==2.31.0; python_version <= '3.7'
 requests==2.32.2; python_version >= '3.8'
 stomp.py==4.1.23
 typing-extensions==4.7.1
-zipp==0.5.2  # Used in some combinations of Python version and package level
+zipp==3.19.1  # Used in some combinations of Python version and package level

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -34,6 +34,7 @@ pydantic==1.10.13
 typer==0.12.0
 typer-cli==0.12.0
 typer-slim==0.12.0
+psutil==6.0.0
 
 # Unit test (imports into testcases):
 pytest==6.2.5


### PR DESCRIPTION
Rolls back PR #599 into 1.7.1.