### PR TITLE
Preparation for support of redundant HMCs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -853,11 +853,11 @@ The exporter config file is in YAML format and has the following structure:
 
     version: 2
 
-    hmc:
-      host: {hmc-ip-address}
-      userid: {hmc-userid}
-      password: {hmc-password}
-      verify_cert: {hmc-verify-cert}
+    hmcs:
+      - host: {hmc-ip-address}
+        userid: {hmc-userid}
+        password: {hmc-password}
+        verify_cert: {hmc-verify-cert}
 
     prometheus:  # optional
       port: {prom-port}

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -305,16 +305,16 @@ class TestCreateContext(unittest.TestCase):
         hmc_api_version = (2, 37)
         hmc_features = []
         config_dict = {
-            "hmc": {
-                "host": "192.168.0.0", "userid": "user", "password": "pwd"
-            },
+            "hmcs": [
+                {"host": "192.168.0.0", "userid": "user", "password": "pwd"}
+            ],
         }
         session = zhmc_prometheus_exporter.create_session(
             config_dict, "filename")
         config_dict = {
-            "hmc": {
-                "host": "192.168.0.0", "userid": "user", "password": "pwd"
-            },
+            "hmcs": [
+                {"host": "192.168.0.0", "userid": "user", "password": "pwd"}
+            ],
             "metric_groups": {}
         }
         yaml_metric_groups = {}
@@ -528,9 +528,9 @@ class TestInitZHMCUsageCollector(unittest.TestCase):
 
         session = setup_faked_session()
         config_dict = {
-            "hmc": {
-                "host": "192.168.0.0", "userid": "user", "password": "pwd"
-            },
+            "hmcs": [
+                {"host": "192.168.0.0", "userid": "user", "password": "pwd"}
+            ],
             "metric_groups": {
                 "dpm-system-usage-overview": {"export": True},
             }
@@ -583,9 +583,9 @@ class TestInitZHMCUsageCollector(unittest.TestCase):
 
         session = setup_faked_session()
         config_dict = {
-            "hmc": {
-                "host": "192.168.0.0", "userid": "user", "password": "pwd"
-            },
+            "hmcs": [
+                {"host": "192.168.0.0", "userid": "user", "password": "pwd"}
+            ],
             "metric_groups": {
                 "dpm-system-usage-overview": {"export": True},
             }

--- a/tests/test_config_upgrade.py
+++ b/tests/test_config_upgrade.py
@@ -84,8 +84,8 @@ TESTCASES_UPGRADE_CONFIG_FILE = [
   password: mypassword
 """,
         f"""version: 2
-hmc:
-  host: 9.10.11.12
+hmcs:
+- host: 9.10.11.12
   userid: myuser
   password: mypassword
   verify_cert: true
@@ -112,8 +112,8 @@ extra_labels:
   value: HMC1
 """,
         f"""version: 2
-hmc:
-  host: 9.10.11.12
+hmcs:
+- host: 9.10.11.12
   userid: myuser
   password: mypassword
   verify_cert: false
@@ -145,8 +145,8 @@ extra_labels:
 """,
         f"""# exporter config file
 version: 2
-hmc:
-  host: 9.10.11.12
+hmcs:
+- host: 9.10.11.12
   userid: myuser
   password: mypassword
   verify_cert: false
@@ -167,8 +167,8 @@ extra_labels:
     (
         "Version 2 config file without metric_groups",
         """version: 2
-hmc:
-  host: 9.10.11.12
+hmcs:
+- host: 9.10.11.12
   userid: myuser
   password: mypassword
   verify_cert: false
@@ -177,8 +177,8 @@ extra_labels:
   value: HMC1
 """,
         """version: 2
-hmc:
-  host: 9.10.11.12
+hmcs:
+- host: 9.10.11.12
   userid: myuser
   password: mypassword
   verify_cert: false
@@ -196,14 +196,14 @@ extra_labels:
     (
         "Version 2 config file without verify_cert",
         """version: 2
-hmc:
-  host: 9.10.11.12
+hmcs:
+- host: 9.10.11.12
   userid: myuser
   password: mypassword
 """,
         """version: 2
-hmc:
-  host: 9.10.11.12
+hmcs:
+- host: 9.10.11.12
   userid: myuser
   password: mypassword
 """,
@@ -217,15 +217,15 @@ hmc:
     (
         "Version 2 config file with metric_groups",
         f"""version: 2
-hmc:
-  host: 9.10.11.12
+hmcs:
+- host: 9.10.11.12
   userid: myuser
   password: mypassword
 {DEFAULT_METRIC_GROUPS}
 """,
         f"""version: 2
-hmc:
-  host: 9.10.11.12
+hmcs:
+- host: 9.10.11.12
   userid: myuser
   password: mypassword
 {DEFAULT_METRIC_GROUPS}
@@ -246,19 +246,19 @@ hmc:
         None,
         [],
         zhmc_prometheus_exporter.ImproperExit,
-        r"^The exporter config file must specify either the new 'hmc' item "
+        r"^The exporter config file must specify either the new 'hmcs' item "
         r"or the old 'metrics' item, but it specifies none\.$"
     ),
 
     (
-        "Invalid version 1 config file with both 'metrics' and 'hmc' items",
+        "Invalid version 1 config file with both 'metrics' and 'hmcs' items",
         """metrics:
   hmc: 9.10.11.12
   userid: myuser
   password: mypassword
   verify_cert: false
-hmc:
-  host: 9.10.11.12
+hmcs:
+- host: 9.10.11.12
   userid: myuser
   password: mypassword
   verify_cert: false
@@ -266,15 +266,15 @@ hmc:
         None,
         [],
         zhmc_prometheus_exporter.ImproperExit,
-        r"^The exporter config file must specify either the new 'hmc' item "
+        r"^The exporter config file must specify either the new 'hmcs' item "
         r"or the old 'metrics' item, but it specifies both\.$"
     ),
 
     (
         "Config file with unknown version",
         """version: 3
-hmc:
-  host: 9.10.11.12
+hmcs:
+- host: 9.10.11.12
   userid: myuser
   password: mypassword
   verify_cert: false

--- a/zhmc_prometheus_exporter/schemas/config_schema.yaml
+++ b/zhmc_prometheus_exporter/schemas/config_schema.yaml
@@ -10,27 +10,30 @@ properties:
   version:
     description: "Version of the config file format"
     type: integer
-  hmc:
-    description: The HMC host and credentials
-    type: object
-    required:
-      - host
-      - userid
-      - password
-    additionalProperties: false
-    properties:
-      host:
-        description: "Hostname or IP address of HMC"
-        type: string
-      userid:
-        description: "Userid used by the exporter to log on to the HMC"
-        type: string
-      password:
-        description: "Password of the HCM userid"
-        type: string
-      verify_cert:
-        description: "Controls whether and how the HMC certificate is verified. For details, see doc section 'HMC certificate'"
-        type: [boolean, string]
+  hmcs:
+    description: The set of redundant HMCs
+    type: array
+    default: []
+    items:
+      type: object
+      required:
+        - host
+        - userid
+        - password
+      additionalProperties: false
+      properties:
+        host:
+          description: "Hostname or IP address of HMC"
+          type: string
+        userid:
+          description: "Userid used by the exporter to log on to the HMC"
+          type: string
+        password:
+          description: "Password of the HCM userid"
+          type: string
+        verify_cert:
+          description: "Controls whether and how the HMC certificate is verified. For details, see doc section 'HMC certificate'"
+          type: [boolean, string]
   metrics:
     description: "Deprecated: The HMC host and credentials"
     type: object


### PR DESCRIPTION
For details, see the commit message.

The support for redundant HMCs is described in issue #597, but is targeted for a future version. This PR prepares that future support by changing the exporter config file now (where it is changed anyway) in order to avoid another incompatible change in the future.