### PR TITLE
Fixed coveralls not found on MacOS with py39-311

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,11 @@ jobs:
               }, \
               { \
                 \"os\": \"macos-latest\", \
+                \"python-version\": \"3.11\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
                 \"python-version\": \"3.12\", \
                 \"package_level\": \"minimum\" \
               }, \
@@ -208,7 +213,6 @@ jobs:
       run: |
         make docker
     - name: Send coverage result to coveralls.io
-      shell: bash -l {0}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_PARALLEL: true

--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ else
   RMDIR_R_FUNC = find . -type d -name '$(1)' | xargs -n 1 rm -rf
   CP_FUNC = cp -r $(1) $(2)
   ENV = env | sort
-  WHICH = which
+  WHICH = which -a
 endif
 
 package_name := zhmc_prometheus_exporter

--- a/changes/noissue.4.fix.rst
+++ b/changes/noissue.4.fix.rst
@@ -1,0 +1,3 @@
+Test: Fixed the issue that coveralls was not found in the test workflow on MacOS
+with Python 3.9-3.11, by running it without login shell. Added Python 3.11 on
+MacOS to the normal tests.


### PR DESCRIPTION
Was reviewed in https://github.com/zhmcclient/python-zhmcclient/pull/1664 - no separate review needed.