### PR TITLE
1.7: Fixed coveralls not found on MacOS with py39-311

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,11 @@ jobs:
               }, \
               { \
                 \"os\": \"macos-latest\", \
+                \"python-version\": \"3.11\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
                 \"python-version\": \"3.12\", \
                 \"package_level\": \"minimum\" \
               }, \
@@ -202,7 +207,6 @@ jobs:
       run: |
         make docker
     - name: Send coverage result to coveralls.io
-      shell: bash -l {0}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_PARALLEL: true

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ else
   RMDIR_R_FUNC = find . -type d -name '$(1)' | xargs -n 1 rm -rf
   CP_FUNC = cp -r $(1) $(2)
   ENV = env | sort
-  WHICH = which
+  WHICH = which -a
 endif
 
 package_name := zhmc_prometheus_exporter

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -34,6 +34,10 @@ Released: 2024-08-19
   either leading to an immediate IndexError, or to follow-on errors lateron.
   (issue #605)
 
+* Test: Fixed the issue that coveralls was not found in the test workflow on MacOS
+  with Python 3.9-3.11, by running it without login shell. Added Python 3.11 on
+  MacOS to the normal tests.
+
 
 Version 1.7.0
 ^^^^^^^^^^^^^


### PR DESCRIPTION
Rolls back PR #624 into 1.7.2.