### PR TITLE
Support for and test of Python 3.13.0-rc.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         if [[ "${{ github.event_name }}" == "schedule" || "${{ github.head_ref }}" =~ ^release_ ]]; then \
           echo "matrix={ \
             \"os\": [ \"ubuntu-latest\", \"macos-latest\", \"windows-latest\" ], \
-            \"python-version\": [ \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\" ], \
+            \"python-version\": [ \"3.8\", \"3.9\", \"3.10\", \"3.11\", \"3.12\", \"3.13.0-rc.1\" ], \
             \"package_level\": [ \"minimum\", \"latest\" ] \
           }" >> $GITHUB_OUTPUT; \
         else \
@@ -54,6 +54,16 @@ jobs:
               { \
                 \"os\": \"ubuntu-latest\", \
                 \"python-version\": \"3.8\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.13.0-rc.1\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"ubuntu-latest\", \
+                \"python-version\": \"3.13.0-rc.1\", \
                 \"package_level\": \"latest\" \
               }, \
               { \
@@ -77,6 +87,16 @@ jobs:
                 \"package_level\": \"latest\" \
               }, \
               { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.13.0-rc.1\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"macos-latest\", \
+                \"python-version\": \"3.13.0-rc.1\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
                 \"os\": \"windows-latest\", \
                 \"python-version\": \"3.12\", \
                 \"package_level\": \"minimum\" \
@@ -84,6 +104,16 @@ jobs:
               { \
                 \"os\": \"windows-latest\", \
                 \"python-version\": \"3.12\", \
+                \"package_level\": \"latest\" \
+              }, \
+              { \
+                \"os\": \"windows-latest\", \
+                \"python-version\": \"3.13.0-rc.1\", \
+                \"package_level\": \"minimum\" \
+              }, \
+              { \
+                \"os\": \"windows-latest\", \
+                \"python-version\": \"3.13.0-rc.1\", \
                 \"package_level\": \"latest\" \
               } \
             ] \

--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -8,4 +8,4 @@
 pip>=23.3
 setuptools>=70.0.0
 setuptools-scm[toml]>=8.1.0
-wheel>=0.38.1
+wheel>=0.41.3

--- a/changes/517.feature.rst
+++ b/changes/517.feature.rst
@@ -1,0 +1,2 @@
+Support for and test of Python 3.13.0-rc.1. Needed to increase the minimum
+versions of PyYAML to 6.0.2 and pyrsistent to 0.20.0.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -65,7 +65,7 @@ ruff>=0.3.5
 pylint>=3.0.1
 astroid>=3.0.1
 lazy-object-proxy>=1.4.3
-wrapt>=1.14
+wrapt>=1.15
 # platformdirs is also used by tox
 platformdirs>=4.1.0
 # isort 4.3.8 fixes an issue with py310 and works on py310 (Note that isort 5.10.0 has official support for py310)
@@ -94,7 +94,7 @@ sphinxcontrib-serializinghtml>=1.1.5; python_version == '3.8'
 sphinxcontrib-serializinghtml>=1.1.9; python_version >= '3.9'
 sphinxcontrib-websupport>=1.2.4
 autodocsumm>=0.2.12
-Babel>=2.9.1
+Babel>=2.11.0
 
 # Twine (no imports, invoked via twine script):
 twine>=3.0.0

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -61,7 +61,7 @@ ruff==0.3.5
 pylint==3.0.1
 astroid==3.0.1
 lazy-object-proxy==1.4.3
-wrapt==1.14
+wrapt==1.15
 platformdirs==4.1.0
 isort==4.3.8
 tomlkit==0.10.1
@@ -85,7 +85,7 @@ sphinxcontrib-serializinghtml==1.1.5; python_version == '3.8'
 sphinxcontrib-serializinghtml==1.1.9; python_version >= '3.9'
 sphinxcontrib-websupport==1.2.4
 autodocsumm==0.2.12
-Babel==2.9.1
+Babel==2.11.0
 
 # Twine (no imports, invoked via twine script):
 # readme-renderer (used by twine, uses Pygments)

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -14,7 +14,7 @@ pip==23.3
 setuptools==70.0.0
 # Note on not specifying 'setuptools-scm[toml]': Extras cannot be in constraints files
 setuptools-scm==8.1.0
-wheel==0.38.1
+wheel==0.41.3
 
 
 # Direct dependencies for install (must be consistent with requirements.txt)
@@ -31,10 +31,10 @@ ruamel.yaml==0.18.6
 
 # Indirect dependencies for install that are needed for some reason (must be consistent with requirements.txt)
 
-# PyYAML is used by zhmcclient 1.17
-PyYAML==5.3.1
+# PyYAML is also used by zhmcclient 1.17, yamlloader
+PyYAML==6.0.2
 
-pyrsistent==0.18.1
+pyrsistent==0.20.0
 
 
 # All other indirect dependencies for install that are not in requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.8"
 dynamic = ["version", "dependencies", "optional-dependencies"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,17 +26,14 @@ ruamel.yaml>=0.18.6
 
 # Indirect dependencies for install that are needed for some reason (must be consistent with minimum-constraints-install.txt)
 
-# PyYAML is used by zhmcclient 1.17
-# PyYAML 5.3.x has wheel archives for Python 2.7, 3.5 - 3.9
-# PyYAML 5.4.x has wheel archives for Python 2.7, 3.6 - 3.9
-# PyYAML 6.0.0 has wheel archives for Python 3.6 - 3.11
-# PyYAML 6.0.1 has wheel archives for Python 3.6 - 3.12
+# PyYAML is also used by zhmcclient 1.17, yamlloader
+# PyYAML 6.0 has wheel archives for Python 3.6 - 3.11
 # PyYAML versions without wheel archives fail install since Cython 3 was
 #   released, see https://github.com/yaml/pyyaml/issues/724.
-PyYAML>=5.3.1,!=5.4.0,!=5.4.1; python_version <= '3.11'
-PyYAML>=5.3.1,!=5.4.0,!=5.4.1,!=6.0.0; python_version >= '3.12'
+# PyYAML 6.0.2 provides wheel archives for Python 3.13 on Windows
+PyYAML>=6.0.2
+
 
 # pyrsistent is used by jsonschema 3.x (no longer by jsonschema 4.x)
-# pyrsistent 0.15.0 fixes import errors on Python>=3.10, but only 0.18.1 has
-#   Python 3.10 support (accordong to the change log).
-pyrsistent>=0.18.1
+# pyrsistent 0.20.0 has official support for Python 3.12
+pyrsistent>=0.20.0


### PR DESCRIPTION
For details, see the commit message.

Note, this tests with 3.13.0 RC1. Issue #525 will upgrade that to the GA version of 3.13.0, once released.