### PR TITLE
Release 2.0.0 - finally

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -155,32 +155,13 @@ jobs:
         # fetch-depth 0 checks out all history for all branches and tags.
         # This is needed to get the authors from git.
         fetch-depth: 0
-
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
-
-    - name: Debug - Display git log count
-      run: |
-        git log --oneline | wc
-
-    - name: Debug - Display git authors
-      run: |
-        git shortlog --summary --email
-
-    - name: Debug - Display git status
-      run: |
-        git status
-
     - name: Development setup
       run: |
         make develop
-
-    - name: Debug - Display git status
-      run: |
-        git status
-
     - name: Display Python packages
       run: |
         pip list
@@ -192,11 +173,6 @@ jobs:
     - name: Display the distribution directory
       run: |
         ls -l dist
-
-    - name: Fail
-      run: |
-        false
-
     - name: Publish distribution to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/Makefile
+++ b/Makefile
@@ -479,7 +479,7 @@ AUTHORS.md: _always
 	sh -c "ls -l log.tmp"
 	sh -c "cat log.tmp >>AUTHORS.md.tmp"
 	echo '```' >>AUTHORS.md.tmp
-	sh -c "if ! grep -q '[^[:space:]]' log.tmp; then echo 'Warning - git shortlog does not display any authors - leaving AUTHORS.md file unchanged'; else if ! diff -q AUTHORS.md.tmp AUTHORS.md; then echo 'Updating AUTHORS.md:'; diff AUTHORS.md.tmp AUTHORS.md; mv AUTHORS.md.tmp AUTHORS.md; else echo 'AUTHORS.md was already up to date'; fi; fi"
+	sh -c "if ! grep -q '[^[:space:]]' log.tmp; then echo 'Warning - git shortlog does not display any authors - leaving AUTHORS.md file unchanged'; else if ! diff -q AUTHORS.md.tmp AUTHORS.md; then echo 'Updating AUTHORS.md as follows:'; diff AUTHORS.md.tmp AUTHORS.md; mv AUTHORS.md.tmp AUTHORS.md; else echo 'AUTHORS.md was already up to date'; fi; fi"
 	sh -c "rm -f log.tmp AUTHORS.md.tmp"
 
 .PHONY: clean


### PR DESCRIPTION
After a long journey of debugging, it turns out that the problem is that 'git shortlog --summary --email' does not display any authors anymore since today, when run in GitHub Actions.

The fix for now is to make 'make authors' tolerant against that, by dececting there are no authors and then leaving the AUTHORS.md file unchanged.