### PR TITLE
2.0: Disabled the trusted publisher concept of Pypi for the time being

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,9 +16,6 @@ jobs:
     name: Build and publish to PyPI
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
     steps:
 
     #-------- Info gathering and checks
@@ -179,8 +176,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         packages-dir: dist
-        # Pypi has a trusted publisher defined, so we do not need a password:
-        # https://pypi.org/manage/project/zhmc_prometheus_exporter/settings/publishing/
+        password: ${{ secrets.PYPI_API_TOKEN }}
 
     #-------- Creation of Github release
     - name: Determine whether release on Github exists for the pushed tag

--- a/changes/noissue.3.fix.rst
+++ b/changes/noissue.3.fix.rst
@@ -1,0 +1,3 @@
+Dev: Disabled the trusted publisher concept of Pypi for the time being, to
+avoid the subsequent access errors in the publish workflow that are not yet
+understood.


### PR DESCRIPTION
Rolls back PR #675 into 2.0.1.