### PR TITLE
1.7: Safety issues; Added twine deps; Upgraded zhmcclient to 1.18.2

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -30,6 +30,8 @@ Released: not yet
 
 * Addressed safety issues up to 2025-01-29.
 
+* Upgraded zhmcclient to 1.18.2 to address a security issue.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -28,6 +28,8 @@ Released: not yet
 
 **Bug fixes:**
 
+* Addressed safety issues up to 2025-01-29.
+
 **Enhancements:**
 
 **Cleanup:**

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -23,7 +23,7 @@ zhmcclient==1.14.0
 urllib3==1.26.19
 jsonschema==3.2.0
 six==1.16.0
-Jinja2==3.1.4
+Jinja2==3.1.5
 # PyYAML is also used by dparse
 PyYAML==5.3.1
 

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -17,7 +17,7 @@ wheel==0.38.1
 
 # Direct dependencies for install (must be consistent with requirements.txt)
 
-zhmcclient==1.14.0
+zhmcclient==1.18.2
 # TODO: Use official prometheus-client version (0.21.0 ?) once released.
 # prometheus-client==0.21.0
 urllib3==1.26.19

--- a/minimum-constraints.txt
+++ b/minimum-constraints.txt
@@ -108,6 +108,7 @@ contextlib2==0.6.0
 filelock==3.12.2
 gitdb==4.0.8
 html5lib==1.0.1
+id==1.5.0
 imagesize==1.3.0
 iniconfig==1.1.1  # used by pytest since its 6.0.0
 keyring==18.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 # Direct dependencies for install (must be consistent with minimum-constraints-install.txt)
 
 # zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
-zhmcclient>=1.14.0
+zhmcclient>=1.18.2
 
 # prometheus-client 0.19.0 added support for HTTPS/mTLS
 # prometheus-client 0.20.0 improved HTTPS/mTLS support

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ zhmcclient>=1.14.0
 
 urllib3>=1.26.19
 jsonschema>=3.2.0
-Jinja2>=3.1.4
+Jinja2>=3.1.5
 
 # PyYAML 5.3.x has wheel archives for Python 2.7, 3.5 - 3.9
 # PyYAML 5.4.x has wheel archives for Python 2.7, 3.6 - 3.9


### PR DESCRIPTION
Rolls back PR #691 into 1.7.2.
No review needed.