### PR TITLE
2.0: Docs: Fixed 'hmc' in example config file and explained only 1 HMC.

### DIFF
--- a/changes/703.fix.rst
+++ b/changes/703.fix.rst
@@ -1,0 +1,2 @@
+Docs: Fixed 'hmc' in example config file to be 'hmcs' and explained that at this
+point, only the first HMC in the list is used.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -874,6 +874,9 @@ The exporter config file is in YAML format and has the following structure:
 
 Where:
 
+* ``hmcs`` is a list of HMCs. At this point, only the first item in the list
+  is used.
+
 * ``{hmc-ip-address}`` is the IP address of the HMC.
 
 * ``{hmc-userid}`` is the userid on the HMC to be used for logging on.

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -3,19 +3,20 @@
 # Version of config file format
 version: 2
 
-# HMC and its credentials
-hmc:
-  host: 9.10.11.12
-  userid: userid
-  password: password
-  # Note: The verify_cert parameter controls whether and how the HMC server
-  #       certificate is validated by the exporter. For more details,
-  #       see doc section 'HMC certificate'.
-  # verify_cert: true           # (default) Validate using default CA certs
-  # verify_cert: my_certs_file  # Validate using this CA certs file
-  # verify_cert: my_certs_dir   # Validate using this CA certs directory
-  # verify_cert: false          # Disable validation
-  verify_cert: false
+# HMCs and their credentials.
+# At this point, only the first item in the list is used.
+hmcs:
+  - host: 9.10.11.12
+    userid: userid
+    password: password
+    # Note: The verify_cert parameter controls whether and how the HMC server
+    #       certificate is validated by the exporter. For more details,
+    #       see doc section 'HMC certificate'.
+    # verify_cert: true           # (default) Validate using default CA certs
+    # verify_cert: my_certs_file  # Validate using this CA certs file
+    # verify_cert: my_certs_dir   # Validate using this CA certs directory
+    # verify_cert: false          # Disable validation
+    verify_cert: false
 
 # Communcation with Prometheus
 prometheus:


### PR DESCRIPTION
Rolls back PR #704 into 2.0.
No further review needed.