### PR TITLE
Support for getting data for subset of CPCs

### DIFF
--- a/changes/323.feature.rst
+++ b/changes/323.feature.rst
@@ -1,0 +1,3 @@
+Added an optional 'cpcs' item in the config file that allows to specify a list
+of CPCs for which data should be exported. By default, all CPCs managed by the
+HMC are exported, like before this change.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -973,6 +973,10 @@ The exporter config file is in YAML format and has the following structure:
       - name: {extra-label-name}
         value: {extra-label-value}
 
+    cpcs:  # optional, defaults to all managed CPCs
+      # List of CPCs to export data for:
+      - {cpc-name}
+
     metric_groups:
       # Dict of HMC and resource metric groups
       {hmc-metric-group}:
@@ -1021,6 +1025,16 @@ Where:
 
 * ``{extra-label-value}`` is the label value. The string value is used directly
   without any further interpretation.
+
+* ``cpcs`` (optional) is a list of CPCs for which metrics should be exported.
+  If not specified or null, metrics for all CPCs managed by the HMC are
+  exported. Note that this list applies to all metrics in context of a CPC,
+  including for example partition or adapter metrics. Note that the metric
+  data returned from the HMC does not allow filtering by CPC, so the filtering
+  is performed by the exporter. This causes resources from the other CPCs to be
+  fetched in the startup phase of the exporter.
+
+* ``{cpc-name}`` is the name of a CPC.
 
 * ``{hmc-metric-group}`` is the name of the metric group on the HMC or the
   resource metric group.

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -36,6 +36,10 @@ extra_labels:
   # - name: pod
   #   value: "'mypod'"
 
+# List of CPCs to export data for. Optional, default is all managed CPCs
+cpcs:
+  # - {cpc-name}
+
 # Metric groups to be fetched
 metric_groups:
 

--- a/zhmc_prometheus_exporter/schemas/config_schema.yaml
+++ b/zhmc_prometheus_exporter/schemas/config_schema.yaml
@@ -89,6 +89,13 @@ properties:
         value:
           description: "Label value, as a Jinja2 expression using certain variables"
           type: string
+  cpcs:
+    description: "List of CPCs for which metrics should be exported. Optional, defaults to all managed CPCs."
+    type: [array, "null"]
+    default: null
+    items:
+      description: "CPC name"
+      type: string
   metric_groups:
     description: Export control for the HMC and resource metric groups
     type: object


### PR DESCRIPTION
For details, see the commit message.

The new 'cpcs' item is optional and defaults to the same behavior as before (exporting all managed CPCs).

I tested it with variations of the new 'cpcs' item in the config file.