### PR TITLE
Added metrics to LPAR resource

### DIFF
--- a/changes/374.feature.rst
+++ b/changes/374.feature.rst
@@ -1,0 +1,5 @@
+Added the following metrics for the 'logical-partition-resource' metric group:
+zhmc_partition_partition_number,
+zhmc_partition_last_used_load_parameter,
+zhmc_partition_last_used_load_address,
+zhmc_partition_sysplex_name.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -672,6 +672,10 @@ zhmc_processor_smt_thread0_usage_ratio                  C+D   G     Usage ratio 
 zhmc_processor_smt_thread1_usage_ratio                  C+D   G     Usage ratio of thread 1 of the processor when in SMT mode
 zhmc_partition_description                              C+D   G     Description of the partition (in 'value' label)
 zhmc_partition_processor_usage_ratio                    C+D   G     Usage ratio across all processors of the partition
+zhmc_partition_partition_number                         C     G     Partition number as a hex string, empty string if LPAR is inactive (in 'value' label)
+zhmc_partition_last_used_load_parameter                 C     G     Last used load parameter, empty string if not set (in 'value' label)
+zhmc_partition_last_used_load_address                   C     G     Last used load address as a hex string, 00000 if not available (in 'value' label)
+zhmc_partition_sysplex_name                             C     G     Sysplex name for z/OS and CFCC, empty string otherwise (in 'value' label)
 zhmc_partition_cp_processor_usage_ratio                 C     G     Usage ratio across all CP processors of the partition
 zhmc_partition_ifl_processor_usage_ratio                C     G     Usage ratio across all IFL processors of the partition
 zhmc_partition_icf_processor_usage_ratio                C     G     Usage ratio across all ICF processors of the partition

--- a/zhmc_prometheus_exporter/data/metrics.yaml
+++ b/zhmc_prometheus_exporter/data/metrics.yaml
@@ -379,6 +379,32 @@ metrics:
       labels:
         - name: value
           value: "resource_obj.properties['description']"
+    - properties_expression: "0"
+      exporter_name: partition_number
+      exporter_desc: Partition number as a hex string, empty string if LPAR is inactive
+      labels:
+        - name: value
+          value: "resource_obj.properties['partition-number']"
+    - properties_expression: "0"
+      if: "'last-used-load-parameter' in resource_obj.properties"  # Added in HMC 2.14.0
+      exporter_name: last_used_load_parameter
+      exporter_desc: Last used load parameter, empty string if not set
+      labels:
+        - name: value
+          value: "resource_obj.properties['last-used-load-parameter']"
+    - properties_expression: "0"
+      if: "'last-used-load-address' in resource_obj.properties"  # Added in HMC 2.14.0
+      exporter_name: last_used_load_address
+      exporter_desc: Last used load address as a hex string, 00000 if not available
+      labels:
+        - name: value
+          value: "resource_obj.properties['last-used-load-address']"
+    - properties_expression: "0"
+      exporter_name: sysplex_name
+      exporter_desc: Sysplex name for z/OS and CFCC, empty string otherwise
+      labels:
+        - name: value
+          value: "resource_obj.properties['sysplex-name'] or ''"  # HMC returns None for otherwise
     - property_name: defined-capacity
       exporter_name: defined_capacity_msu_per_hour
       exporter_desc: Defined capacity expressed in terms of Millions of Service Units (MSU)s per hour


### PR DESCRIPTION
For details, see the commit message.

I tested it on T27, including the conversion of None to empty string for sysplex_name.