### PR TITLE
Increased zhmcclient to use its master branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,8 @@ $(done_dir)/check_reqs_$(pymn)_$(PACKAGE_LEVEL).done: $(done_dir)/develop_$(pymn
 	@echo "Makefile: Checking missing dependencies of this package"
 	-$(call RM_FUNC,$@)
 	pip-missing-reqs $(package_name) --requirements-file=requirements.txt
-	pip-missing-reqs $(package_name) --requirements-file=minimum-constraints-install.txt
+# TODO-ZHMC: Re-enable once zhmcclient 1.20.0 is released
+# pip-missing-reqs $(package_name) --requirements-file=minimum-constraints-install.txt
 	@echo "Makefile: Done checking missing dependencies of this package"
 ifeq ($(PLATFORM),Windows_native)
 # Reason for skipping on Windows is https://github.com/r1chardj0n3s/pip-check-reqs/issues/67

--- a/changes/noissue.4.fix.rst
+++ b/changes/noissue.4.fix.rst
@@ -1,0 +1,2 @@
+Increased minimum version of zhmcclient to 1.20.0 to pick up fixes and
+improvements.

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -19,7 +19,9 @@ wheel==0.41.3
 
 # Direct dependencies for install (must be consistent with requirements.txt)
 
-zhmcclient==1.18.2
+# TODO-ZHMC: Re-enable once zhmcclient 1.20.0 is released
+# zhmcclient==1.20.0
+
 # TODO: Use official prometheus-client version (0.21.0 ?) once released.
 # prometheus-client==0.21.0
 urllib3==1.26.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,9 @@
 
 # Direct dependencies for install (must be consistent with minimum-constraints-install.txt)
 
-# zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
-zhmcclient>=1.18.2
+# TODO-ZHMC: Re-enable once zhmcclient 1.20.0 is released
+zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
+# zhmcclient>=1.20.0
 
 # prometheus-client 0.19.0 added support for HTTPS/mTLS
 # prometheus-client 0.20.0 improved HTTPS/mTLS support


### PR DESCRIPTION
No review needed.
Issue https://github.com/zhmcclient/zhmc-prometheus-exporter/issues/714 has been created to move to the released 1.20.0 version of zhmcclient.