### PR TITLE
Cleaned up incorrect metric group type

### DIFF
--- a/changes/noissue.1.cleanup.rst
+++ b/changes/noissue.1.cleanup.rst
@@ -1,0 +1,4 @@
+Cleaned up incorrect metric group type 'hmc' and changed to 'metric' in the
+metric definition file. Made the metric type mandatory in the schema for the
+metric definition file to avoid such issues in the future. Note, this did not
+cause an issue.

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -289,7 +289,10 @@ class TestCreateContext(unittest.TestCase):
             }
         }
         yaml_metric_groups = {
-            "dpm-system-usage-overview": {"prefix": "pre"},
+            "dpm-system-usage-overview": {
+                "type": "metric",
+                "prefix": "pre",
+            },
         }
         cpc_list = client.cpcs.list()
 
@@ -438,6 +441,7 @@ class TestMetrics(unittest.TestCase):
 
         yaml_metric_groups = {
             "dpm-system-usage-overview": {
+                "type": "metric",
                 "prefix": "pre",
             },
             "cpc-resource": {
@@ -544,7 +548,10 @@ class TestInitZHMCUsageCollector(unittest.TestCase):
             }
         }
         yaml_metric_groups = {
-            "dpm-system-usage-overview": {"prefix": "pre"},
+            "dpm-system-usage-overview": {
+                "type": "metric",
+                "prefix": "pre",
+            },
         }
         cpc_list = client.cpcs.list()
 
@@ -602,7 +609,10 @@ class TestInitZHMCUsageCollector(unittest.TestCase):
             }
         }
         yaml_metric_groups = {
-            "dpm-system-usage-overview": {"prefix": "pre"},
+            "dpm-system-usage-overview": {
+                "type": "metric",
+                "prefix": "pre",
+            },
         }
         cpc_list = client.cpcs.list()
 

--- a/zhmc_prometheus_exporter/data/metrics.yaml
+++ b/zhmc_prometheus_exporter/data/metrics.yaml
@@ -7,12 +7,14 @@ metric_groups:
   # Available for CPCs in classic mode
 
   cpc-usage-overview:
+    type: metric
     prefix: cpc
     labels:
       - name: cpc
         value: "resource_obj.name"
 
   logical-partition-usage:
+    type: metric
     prefix: partition
     labels:
       - name: cpc
@@ -21,6 +23,7 @@ metric_groups:
         value: "resource_obj.name"
 
   channel-usage:
+    type: metric
     prefix: channel
     labels:
       - name: cpc
@@ -29,6 +32,7 @@ metric_groups:
         value: "metric_values['channel-name']"  # format: 'CSS.CHPID'
 
   crypto-usage:
+    type: metric
     prefix: crypto_adapter
     if: "hmc_version>='2.12.0'"
     labels:
@@ -38,6 +42,7 @@ metric_groups:
         value: "metric_values['channel-id']"
 
   flash-memory-usage:
+    type: metric
     prefix: flash_memory_adapter
     if: "hmc_version>='2.12.0'"
     labels:
@@ -47,6 +52,7 @@ metric_groups:
         value: "metric_values['channel-id']"
 
   roce-usage:
+    type: metric
     prefix: roce_adapter
     if: "hmc_version>='2.12.1'"
     labels:
@@ -68,6 +74,7 @@ metric_groups:
   # Available for CPCs in DPM mode
 
   dpm-system-usage-overview:
+    type: metric
     prefix: cpc
     if: "hmc_version>='2.13.1'"
     labels:
@@ -75,6 +82,7 @@ metric_groups:
         value: "resource_obj.name"
 
   partition-usage:
+    type: metric
     prefix: partition
     if: "hmc_version>='2.13.1'"
     labels:
@@ -84,6 +92,7 @@ metric_groups:
         value: "resource_obj.name"
 
   adapter-usage:
+    type: metric
     prefix: adapter
     if: "hmc_version>='2.13.1'"
     labels:
@@ -93,6 +102,7 @@ metric_groups:
         value: "resource_obj.name"
 
   network-physical-adapter-port:
+    type: metric
     prefix: port
     if: "hmc_version>='2.13.1'"
     labels:
@@ -104,6 +114,7 @@ metric_groups:
         value: "metric_values['network-port-id']"
 
   partition-attached-network-interface:
+    type: metric
     prefix: nic
     if: "hmc_version>='2.13.1'"
     labels:
@@ -167,12 +178,14 @@ metric_groups:
   # Available for CPCs in any mode
 
   zcpc-environmentals-and-power:
+    type: metric
     prefix: cpc
     labels:
       - name: cpc
         value: "resource_obj.name"
 
   zcpc-processor-usage:
+    type: metric
     prefix: processor
     labels:
       - name: cpc
@@ -183,6 +196,7 @@ metric_groups:
         value: "metric_values['processor-type']"
 
   environmental-power-status:
+    type: metric
     prefix: cpc
     if: "hmc_version>='2.15.0'"
     labels:

--- a/zhmc_prometheus_exporter/schemas/metrics_schema.yaml
+++ b/zhmc_prometheus_exporter/schemas/metrics_schema.yaml
@@ -18,6 +18,7 @@ properties:
         description: "Key: Name of the HMC or resource metric group"
         type: object
         required:
+          - type
           - prefix
         additionalProperties: false
         properties:
@@ -25,7 +26,6 @@ properties:
             description: "The type of metric group: metric - an HMC metric group in which the metric values come from the HMC metric service; resource - an artificial metric group in which the metric values come from resource properties."
             type: string
             enum: [metric, resource]
-            default: metric
           resource:
             description: "The resource class path for a resource metric group, starting at the zhmcclient.Client object (e.g. 'cpc.partition')."
             type: string

--- a/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
+++ b/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
@@ -892,7 +892,7 @@ def create_metrics_context(
     exported_res_metric_groups = []
     for metric_group in yaml_metric_groups:
         mg_dict = yaml_metric_groups[metric_group]
-        mg_type = mg_dict.get("type", 'hmc')
+        mg_type = mg_dict["type"]
         # Not all metric groups may be specified:
         config_mg_item = config_mg_dict.get(metric_group, {})
         export = config_mg_item.get("export", False)
@@ -903,12 +903,11 @@ def create_metrics_context(
                 mg_dict["if"], hmc_version, hmc_api_version, hmc_features,
                 None, None, None)
         if export:
-            if mg_type == 'hmc':
+            if mg_type == 'metric':
                 exported_hmc_metric_groups.append(metric_group)
             else:
                 assert mg_type == 'resource'  # ensured by enum
                 exported_res_metric_groups.append(metric_group)
-
     client = zhmcclient.Client(session)
 
     logprint(logging.INFO, PRINT_V,


### PR DESCRIPTION
For details, see the commit message.

I have tested that the enablement of metrics-based metric groups in the config file is still processed correctly, as before.