### PR TITLE
Improved caching with a consolidated new resource cache

### DIFF
--- a/changes/764.feature.2.rst
+++ b/changes/764.feature.2.rst
@@ -1,0 +1,5 @@
+Improved the handling of missing object access permissions: Resources of
+enabled metric groups now may be inaccessible which causes their metrics not to
+be exported. That had always been documented that way, but the implementation
+did not step up to that. However, the direct and indirect parent resources of
+accessible resources of enabled metric groups also must be accessible.

--- a/changes/764.feature.rst
+++ b/changes/764.feature.rst
@@ -1,0 +1,7 @@
+Improved performance of the startup phase with a consolidated new resource
+cache. So far, there were three caches in the exporter that were built for
+specific purposes. That has lead to fetching the same resources multiple times
+from the HMC and fetching a larger set of resource properties than minimally
+needed. The new resource cache fetches each resource only once and only with
+the smallest possible set of properties. That should reduce the duration of
+the startup phase.

--- a/design/startup.md
+++ b/design/startup.md
@@ -1,6 +1,6 @@
 # Basic flow in the exporter
 
-Applies to version 2.1.0.
+Applies to version 2.2.0.
 
 ## Startup
 
@@ -17,17 +17,23 @@ Applies to version 2.1.0.
   - "List CPC Objects"
   - Returns the accessible CPCs
 * Check that "cpcs" config property does not specify unknown CPCs
-* Define the set of cpcs based on the "cpcs" config property. We refer to
-  that as `cpc_list`.
-* For each CPC in `cpc_list`:
+* Determine the target CPCs based on the "cpcs" config property.
+* For each target CPC:
+  * Get SE version
+    - "Get CPC Properties"
   * List API features of the CPC
     - "List CPC API Features"
-* Create metrics context
-  - With `cpc_list`
+* Determine the metric groups enabled for export based on the "metric_groups"
+  config property, separately for resource-based and metric-based metric groups.
+* If there are metric-based metric groups enabled, create a metrics context
+  for them.
   - "Create Metrics Context"
-* Create `ResourceCache()`
-* Create `ZHMCUsageCollector()`
-  - knows about `ResourceCache`
+* Create resource cache
+  - `ResourceCache()`
+* Fetch resources into the resource cache
+  - call `ResourceCache.setup()`
+* Create collector
+  - `ZHMCUsageCollector()`, knows the `ResourceCache`
 * Register the collector and perform first collection
   - see [Collection](#collection)
 * Start HTTP server for Prometheus
@@ -47,86 +53,85 @@ Prometheus performs this call as configured (e.g. every 30 seconds).
 `ZHMCUsageCollector.collect()`:
 
 * Log message "Collecting metrics"
-* Loop until successful:
-  * Get Metrics from HMC
+* If there are metric-based metric groups enabled, retrieve metrics from HMC
+  * Loop until successful:
     - call `retrieve_metrics()`
-* Log message: "Building family objects for HMC metrics"
-* Call `build_family_objects()`
+  * Log message: "Building family objects for HMC metrics"
+  * Call `build_family_objects()`
 * Log message: "Building family objects for resource metrics"
 * Call `build_family_objects_res()`
 * Log message: "Returning family objects"
 * Yield family objects (back to Prometheus)
 * Log message: "Done collecting metrics"
 
-`retrieve_metrics()`:
-
-TBD
-
-`build_family_objects()`:
-
-TBD
-
-`build_family_objects_res()`:
-
-TBD
-
 ## Resource data kept in the exporter
 
-There are several places where resource data is kept (cached) in the exporter:
+There is a single resource cache where resource data is kept in the exporter:
 
-* Attributes of the `ZHMCUsageCollector` object:
+* `ResourceCache`
 
-  * `self.resources` and `self.uri2resource`:
+  - Known by every class/function that needs to access resources
 
-    These attributes are used only for resource metric groups.
-    Both attributes contain the same (= same object ID) zhmcclient resource
-    objects, for resource metric groups that are enabled, for only the CPCs
-    on `cpc_list`. These resource objects are all auto-update enabled.
+    - `ZHMCUsageCollector` class
+    - `expand_group_label_value()` function
+    - `expand_metric_label_value()` function
+    - `build_family_objects()` function
+    - `build_family_objects_res()` function
 
-    `self.resources` is a dict with key = metric group name, value = list of
-    zhmcclient resource objects for the resources defined in enabled resource
-    metric groups.
+  - Based on the currently defined metric groups, the cache stores the following
+    resource classes for use as metric resources (and for use in label values):
 
-    `self.uri2resource` is a dict with key = resource URI, value = zhmcclient
-    resource object for the resources defined in enabled resource metric
-    groups.
+    - cpc
+    - adapter
+    - logical-partition
+    - partition
+    - nics
+    - storage-group
+    - storage-volume
 
-    The zhmcclient resource objects in these attributes are:
-      - For the "partition-resource" metric group: All (accessible) partitions
-        on all CPCs in `cpc_list`.
-      - For the "storagegroup-resource" metric group: All (accessible) storage
-        groups.
-        TODO: Optimization: This should be reduced to only the storage
-        groups associated with the CPCs in `cpc_list`.
-      - For the "storagevolume-resource" metric group: All storage volumes in
-        all (accessible) storage groups.
-        TODO: Optimization: This should be reduced to only the storage
-        groups associated with the CPCs in `cpc_list`.
-      - For the "adapter-resource" metric group: All (accessible) adapters on
-        all CPCs in `cpc_list`.
-      - For the "cpc-resource" metric group: All (accessible) CPCs in
-       `cpc_list`.
+  - In addition, the cache stores the following resource classes for use in
+    label values:
 
-  * `self.resource_cache`
+    - virtual-switch (only up to z16 CPCs)
+    - port (only for network and storage adapters)
 
-    This attribute is used only for HMC metric groups.
+    For 'port', the resource class names in the actual resource objects are
+    'storage-port' and 'network-port', but the cache stores them together
+    and uses the artificial resource class name 'port'.
 
-    It is a `ResourceCache` object where resources can be looked up by URI.
-    The resource URIs are provided in the retrieved metric data, and
-    the `ResourceCache.resource()` method looks up the resource by URI, or
-    if not yet in the cache, finds the resource on the HMC based on the URI
-    and puts it into the cache.
+  - The resource cache knows about dependencies of resources. For example,
+    when a metric group for partitions is enabled, it knows that the resource
+    objects for the parent CPCs also need to be fetched, so that the processing
+    of labels can navigate to the parent resources without having to fetch
+    additional resources from the HMC. The dependencies can be seen in the
+    `_setup_<resource>()` methods of `ResourceCache`.
 
-    The resource objects in the cache are zhmcclient resource objects.
-    They are not auto-update enabled.
+  - Object accessibility: If the HMC user does not have object access permission
+    to a resource object, the HMC omits it in List operations, or considers
+    it as not found when its URI is used in an operation.
 
-    TODO: Optimization: Finding the resources on the HMC is done resource by
-    resource. It would be more efficient to list the resources once.
+    Not each resource class has its own object access permissions in the HMC.
+    For example, NIC objects are child element objects of partitions and do
+    not have their own access permissions.
+
+    There are cases where the URIs of resources are surfaced that have their
+    own object access permissions. For example, partitions and adapters
+    have a "parent" property that is the parent CPC, or storage groups have
+    a "cpc-uri" property for the associated CPC.
+
+    The resource cache and the rest of the exporter currently tolerates missing
+    object access for resources of enabled metric groups and then does not show
+    their metrics, but once a resource of an enabled metric group is accessible,
+    its direct and indirect parent resources also must be accessible.
+
+  - For more details about the cache, look at the descriptions in the
+    `ResourceCache` class.
 
 ## Fetch thread
 
-The fetch thread runs forever. It fetches data for resources or properties that
-do not support update notifications.
+The fetch thread runs forever. It fetches data for resource classes that
+are needed for enabled metric groups and do not support update notifications,
+only for the target CPCs.
 
 The fetch thread has a loop where it waits for a variable sleep time
 and then performs the actual fetches.
@@ -134,7 +139,7 @@ and then performs the actual fetches.
 The sleep time is adjusted according to the intervals in which Prometheus
 fetches the data.
 
-`run_fetch_thread()`
+`ZHMCUsageCollector.run_fetch_thread()`
 
 * Determine properties to be fetched from `ZHMCUsageCollector.yaml_fetch_properties`.
 
@@ -149,19 +154,16 @@ fetches the data.
     - a total of 22 properties on a z16 CPC
 
 * Fetch the LPAR properties:
-  It does that by using single call to `console.list_permitted_lpars()`
-  where `additional_properties` is set to the LPAR properties that are needed.
-
-  TODO: This returns data for LPARs that are not in the `cpc_list`. Optimize.
+  It does that by using single call to `console.list_permitted_lpars()`,
+  with filters for the target CPCs and `additional_properties` which is set to
+  the LPAR properties that are needed.
 
 * Fetch the CPC properties:
-  It does that by looping through the `cpc_list`, and for each CPC, it
+  It does that by looping through the target CPCs. For each CPC, it
   performs `cpc.pull_properties(cpc_props)` to retrieve only the properties
-  that are needed, from only the CPCs that are needed.
+  that are needed.
 
 * Adjust the sleep time
   - Log message "Increasing/Decreasing sleep time for fetching properties in background"
 
-* Update properties of the local resource objects from the fetch results
-  * `ZHMCUsageCollector.uri2resource`
-  * `ZHMCUsageCollector.resources`
+* Update properties of the resources in the resource cache from the fetch results.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -327,6 +327,11 @@ accordingly:
   successfully return metrics for objects with access permission, and ignore
   any others.
 
+  However, the parent objects of accessible objects of enabled metric groups
+  also must be accessible for the user. This boils down to access permissions
+  for the parent CPC, when metric groups for LPARs, partitions or adapters
+  are enabled for export.
+
   The exporter can return metrics for the following types of objects. To
   return metrics for all existing objects, the userid must have object access
   permission to all of the following objects:

--- a/zhmc_prometheus_exporter/_resource_cache.py
+++ b/zhmc_prometheus_exporter/_resource_cache.py
@@ -1,4 +1,4 @@
-# Copyright 2018,2025 IBM Corp. All Rights Reserved.
+# Copyright 2025 IBM Corp. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,68 +13,1178 @@
 # limitations under the License.
 
 """
-A resource cache for resources needed for metric-based metric groups.
+A resource cache for the IBM Z HMC Prometheus Exporter.
 """
 
+import re
 import logging
 import zhmcclient
-from ._logging import PRINT_ALWAYS, PRINT_VV, logprint
+import zhmcclient_mock
+
+from ._logging import PRINT_V, PRINT_VV, PRINT_ALWAYS, logprint
+from ._exceptions import InvalidMetricDefinitionFile
 
 
 class ResourceCache:
-    # pylint: disable=too-few-public-methods
+    # pylint: disable=too-many-instance-attributes,line-too-long
     """
-    Cache for zhmcclient resource objects to avoid having to look them up
-    repeatedly.
-    """
+    A resource cache for the exporter.
 
-    def __init__(self):
-        self._resources = {}  # dict URI -> Resource object
+    This is the only resource cache in the exporter. It contains the
+    zhmcclient resource objects for all use cases:
 
-    def resource(self, uri, object_value):
+    * To resolve the resource URIs returned by the HMC metric service into
+      zhmcclient resource objects.
+    * To know which resources provide resource-based metric groups, and to get
+      their properties.
+    * To get the properties of resources for use in metric labels.
+
+    The resource objects in the cache are:
+
+    * The resource objects that are defined as resource classes of enabled
+      metric groups, for the target CPCs.
+    * The direct and indirect parent objects of these resource objects for the
+      target CPCs, because the metric labels are defined to show the names of
+      parent resources.
+    * Additional resources referenced by the metric labels, for the target CPCs.
+    * The resources of non-target CPCs for enabled metric-based metric groups,
+      because the HMC metric service does not allow to filter its results by
+      CPC and the cache needs to support resolving all returned resource URIs
+      in order to determine whether the returned metric value is for a target
+      CPC.
+
+    The different resource classes in the cache are used as follows:
+
+    Resource class      Metric   Resource   Labels   Dependents
+                        based    based
+    ---------------------------------------------------------------------------
+    cpc                 Yes      Yes        Yes      -
+    adapter             Yes      Yes        Yes      cpc
+    logical-partition   Yes      Yes        Yes      cpc
+    partition           Yes      Yes        Yes      cpc,storage-group
+    nic                 Yes      No         Yes      cpc,partition
+    virtual-switch      No       No         No (1)   part.,adapter,port,vswitch
+    port (2)            No       No         Yes      cpc,adapter
+    storage-group       No       Yes        Yes      cpc
+    storage-volume      No       Yes        Yes      cpc,sto-grp
+
+    (1) The vswitch resource is needed up to z16 CPCs to find the backing
+        adapter of a NIC.
+    (2) The resource class names in the actual resource objects are
+        'storage-port' and 'network-port', but the cache stores them together
+        and uses the artificial resource class name 'port'.
+
+    The resource objects in the cache that are used for at least one enabled
+    resource-based metric group will be auto-update enabled. All other
+    zhmcclient resource objects in the cache are not auto-update enabled.
+    This means that resources used for labels will not always be auto-update
+    enabled, but that typically affects only the resource name.
+
+    Where possible, the zhmcclient resource objects in the cache have only the
+    minimal set of properties that is needed:
+
+    Resource class      Without auto-update                  With auto-update
+    -------------------------------------------------------------------------
+    cpc                 as prepared in cpc_list              all
+    adapter             from List HMC operation              all
+    logical-partition   from List HMC operation              all
+    partition           from List HMC operation + nic-uris   all
+    nic                 all (1)                              N/A
+    virtual-switch      from List HMC operation              N/A
+    port                all (1)                              N/A
+    storage-group       N/A                                  all
+    storage-volume      N/A                                  all
+
+    (1) For element objects, there is no List HMC operation, so the zhmcclient
+        'list()' method returns all properties, since it needs to loop through
+        the referenced element objects anyway.
+
+    Object access permissions are handled by the cache such that objects without
+    access are stored in the all-resources dict with a None value, so that the
+    cache remembers that they are inaccessible and does not retry fetching them
+    over and over again.
+    """  # noqa: E501
+
+    def __init__(self, client, all_cpc_list, target_cpc_list, mdf_metric_groups,
+                 exported_mg_names, se_features_by_cpc):
         """
-        Return the zhmcclient resource object for the URI, updating the cache
-        if not present.
+        Parameters:
+
+          client (zhmcclient.Client): Client object used for communicating
+            with the HMC. This object will get all the cached resources
+            added.
+
+          all_cpc_list (list of zhmcclient.Cpc): All managed CPCs.
+
+          target_cpc_list (list of zhmcclient.Cpc): Target CPCs for which
+            metrics are to be exported. The target CPCs can be defined in the
+            exporter config file.
+
+          mdf_metric_groups (dict): All metric groups from the metric definition
+            file (i.e. the value of the 'metric_groups' item in the file).
+
+          exported_mg_names (list of str): Names of the metric groups that
+            are set to be exported in the exporter config file. This includes
+            both metric-based and resource-based metric groups.
+
+          se_features_by_cpc (dict): Names of SE API features for each CPC.
+            Key: CPC name
+            Value: List of str: Names of SE API features for the CPC
+        """
+        self._client = client
+        self._all_cpc_list = all_cpc_list
+        self._target_cpc_list = target_cpc_list
+        self._mdf_metric_groups = mdf_metric_groups
+        self._exported_mg_names = exported_mg_names
+        self._se_features_by_cpc = se_features_by_cpc
+
+        # Indicator that setup() was called
+        self._setup_called = False
+
+        # Some objects for faster access
+        self._console = client.consoles.console
+        self._session = client.session
+
+        # Target CPC URI list
+        #
+        # This list is set up to have the same CPCs as in target_cpc_list.
+        # This is used to check whether new resource objects are in a target
+        # CPC. Note that the set of target CPCs is static over the lifetime of
+        # an exporter run.
+        #
+        # List of str: URI of the CPC.
+        self._target_cpc_uri_list = None  # Deferred initialization
+
+        # Auto-update enablement dict
+        #
+        # This dict is set based on the metric groups that are enabled for
+        # export: If the metric groups for a particular resource class has
+        # one or more resource-based metric groups, auto-update gets enabled.
+        # This dict has only items for resource classes of metric groups that
+        # are enabled for export.
+        #
+        # Key: Resource class.
+        # Value: Boolean indicating that auto-update should be enabled for the
+        # resource class.
+        self._auto_update = {}
+
+        # All-resources dict
+        #
+        # This dict contains all resources in the cache. This includes
+        # accessible resources as well as inaccessible URIs that are returned
+        # by the HMC metric service.
+        # This dict is used when a global lookup of a resource URI is performed,
+        # for example when processing metric-based metrics.
+        #
+        # Key: Resource URI.
+        # Value: zhmcclient.BaseResource if the resource is accessible, or None
+        # if the resource is not accessible.
+        self._all_resources_by_uri = {}
+
+        # All-resource list dicts
+        #
+        # These dicts exist for certain resource classes in order to list their
+        # resources. Each dict contains all resources of the resource class,
+        # for all CPCs.
+        #
+        # The resource objects in this dict are the same (= same object ID)
+        # Python objects as in the all-resources dict. The Python object ID is
+        # used as a key in order to save memory and make the lookup faster.
+        #
+        # Key: Python object ID of the resource object.
+        # Value: zhmcclient.BaseResource
+        self._all_partitions_by_id = {}
+        self._all_storage_groups_by_id = {}
+
+        # Resource-based resource dict
+        #
+        # This dict contains only the resources needed for resource-based
+        # metric groups that are enabled for export and only for the target
+        # CPCs. This dict is used when building the family objects to be
+        # returned to Prometheus for resource-based metric groups.
+        #
+        # The resource objects in this dict are the same (= same object ID)
+        # Python objects as in the all-resources dict.
+        #
+        # Key: Metric group name
+        # Value: list of zhmcclient.BaseResource
+        self._resource_based_resources_by_mg = {}
+
+        # Target CPC resource dict
+        #
+        # This dict contains the subset of resources in the all-resources dict
+        # that are in the target CPCs. This dict is used when processing the
+        # data returned by the HMC metric service in order to decide whether a
+        # metric belongs to a target CPC.
+        #
+        # The resource objects in this dict are the same (= same object ID)
+        # Python objects as in the all-resources dict. The Python object ID is
+        # used as a key in order to save memory and make the lookup faster.
+        #
+        # Key: Python object ID of the resource object.
+        # Value: zhmcclient.BaseResource
+        self._target_cpc_resources_by_id = {}
+
+        # Resource class dicts
+        #
+        # Each of these dicts contains all resources for a particular resource
+        # class and only for the target CPCs. These dicts are used for
+        # iterating through the resources of a specific resource class.
+        #
+        # The resource objects in these dicts are the same (= same object ID)
+        # Python objects as in the all-resources dict. The Python object ID is
+        # used as a key in order to save memory and make the lookup faster.
+        #
+        # Key: Python object ID of the resource object.
+        # Value: zhmcclient.BaseResource
+        self._cpcs = {}
+        self._adapters = {}
+        self._logical_partitions = {}
+        self._partitions = {}
+        self._nics = {}
+        self._vswitches = {}
+        self._ports = {}  # Ports of only network and storage adapters
+        self._storage_groups = {}
+        self._storage_volumes = {}
+
+        # Lookup dict for getting the resource class dict by resource class.
+        # Note: For vswitches and ports, there is no lookup needed because
+        # they are not a resource of any metric group.
+        self._resource_id_dicts = {
+            'cpc': self._cpcs,
+            'adapter': self._adapters,
+            'logical-partition': self._logical_partitions,
+            'partition': self._partitions,
+            'nic': self._nics,
+            'storage-group': self._storage_groups,
+            'storage-volume': self._storage_volumes,
+        }
+
+    def __repr__(self):
+        """
+        Show the resources in the cache.
+        """
+        repr_lines = []
+        repr_lines.append(f"{self.__class__.__name__} at 0x{id(self):08x} (")
+        for uri, res in self._all_resources_by_uri.items():
+            if res is None:
+                res_class = "unknown"
+                target_str = ""
+                auto_str = ""
+                res_name = "unknown"
+            else:
+                res_class = res.__class__.__name__
+                for_target_cpc = id(res) in self._target_cpc_resources_by_id
+                target_str = "(for target CPC)" if for_target_cpc else ""
+                auto_str = "(auto-update)" if res.auto_update_enabled() else ""
+                res_name = res.properties.get('name', "(name not fetched)")
+            repr_lines.append(
+                f"  {uri}: {res_class} {res_name} {auto_str} {target_str}")
+        repr_lines.append(")")
+        return '\n'.join(repr_lines)
+
+    def _resource_id_dict(self, uri):
+        """
+        Return the resource class dict for the URI.
+        """
+        if re.match(r'/api/storage-groups/[a-f0-9\-]+/'
+                    r'storage-volumes/[a-f0-9\-]+$', uri):
+            return self._storage_volumes
+        if re.match(r'/api/storage-groups/[a-f0-9\-]+$', uri):
+            return self._storage_groups
+        if re.match(r'/api/partitions/[a-f0-9\-]+/nics/[a-f0-9\-]+$', uri):
+            return self._nics
+        if re.match(r'/api/partitions/[a-f0-9\-]+$', uri):
+            return self._partitions
+        if re.match(r'/api/logical-partitions/[a-f0-9\-]+$', uri):
+            return self._logical_partitions
+        if re.match(r'/api/adapters/[a-f0-9\-]+$', uri):
+            return self._adapters
+        if re.match(r'/api/adapters/[a-f0-9\-]+/'
+                    r'(network|storage)-ports/[a-f0-9\-]+$', uri):
+            return self._ports
+        if re.match(r'/api/cpcs/[a-f0-9\-]+/virtual-switches/[a-f0-9\-]+$',
+                    uri):
+            return self._vswitches
+        if re.match(r'/api/cpcs/[a-f0-9\-]+$', uri):
+            return self._cpcs
+        raise ValueError(f"Invalid URI for detecting resource dict: {uri}")
+
+    def _enable_auto_update(self, resource, res_kind, res_name):
+        """
+        Enable auto-update for the specified resource.
+
+        Test mode: If the session is a zhmcclient_mock (faked) session,
+        no auto-update enablement is performed, because the STOMP connection
+        in zhmcclient has no mock support.
+        """
+        if isinstance(self._session, zhmcclient_mock.FakedSession):
+            logprint(
+                logging.INFO, PRINT_V,
+                "Test mode: Ignoring enablement of auto-update for "
+                f"{res_kind} {res_name}")
+            return
+
+        logprint(
+            logging.DEBUG, PRINT_VV,
+            f"Enabling auto-update for {res_kind} {res_name}")
+        try:
+            resource.enable_auto_update()
+        except zhmcclient.Error as exc:
+            logprint(
+                logging.ERROR, PRINT_ALWAYS,
+                "The metric values of resource-based metric groups using "
+                f"{res_kind} {res_name} will not be updated because "
+                "enabling auto-update for it failed with "
+                f"{exc.__class__.__name__}: {exc}")
+
+    @staticmethod
+    def _needs_auto_update(mg_items):
+        """
+        Return boolean indicating whether the set of metric groups needs
+        auto-update enabled.
+
+        That is the case when at least one of the metric groups is
+        resource-based.
+        """
+        if mg_items:
+            for mg_item in mg_items:
+                if mg_item['type'] == 'resource':
+                    return True
+        return False
+
+    def _setup_cpcs(self, mg_items_by_rc):
+        """
+        Setup for resource class 'cpc'.
+
+        This is called during setup() when metric groups for that resource
+        class are enabled for export, or when this resource class is a
+        dependency for other resource classes.
+        """
+        self._auto_update['cpc'] = \
+            self._needs_auto_update(mg_items_by_rc.get('cpc'))
+        if not self._cpcs:
+            for cpc in self._all_cpc_list:
+                self._add_cpc(cpc)
+
+    def _setup_adapters(self, mg_items_by_rc):
+        """
+        Setup for resource class 'adapter'.
+
+        This is called during setup() when metric groups for that resource
+        class are enabled for export, or when this resource class is a
+        dependency for other resource classes.
+        """
+        self._auto_update['adapter'] = \
+            self._needs_auto_update(mg_items_by_rc.get('adapter'))
+        if not self._adapters:
+            self._setup_cpcs(mg_items_by_rc)
+            for cpc in self._all_cpc_list:
+                logprint(
+                    logging.DEBUG, PRINT_VV,
+                    f"Listing adapters of CPC {cpc.name}")
+                adapters = cpc.adapters.list()
+                for adapter in adapters:
+                    self._add_adapter(adapter)
+
+    def _setup_logical_partitions(self, mg_items_by_rc):
+        """
+        Setup for resource class 'logical-partition'.
+
+        This is called during setup() when metric groups for that resource
+        class are enabled for export, or when this resource class is a
+        dependency for other resource classes.
+        """
+        self._auto_update['logical-partition'] = \
+            self._needs_auto_update(mg_items_by_rc.get('logical-partition'))
+        if not self._logical_partitions:
+            self._setup_cpcs(mg_items_by_rc)
+            for cpc in self._all_cpc_list:
+                if cpc.dpm_enabled:
+                    continue
+                logprint(
+                    logging.DEBUG, PRINT_VV,
+                    f"Listing LPARs of classic-mode CPC {cpc.name}")
+                lpars = cpc.lpars.list()
+                for lpar in lpars:
+                    self._add_logical_partition(lpar)
+
+    def _setup_partitions(self, mg_items_by_rc):
+        """
+        Setup for resource class 'partition'.
+
+        This is called during setup() when metric groups for that resource
+        class are enabled for export, or when this resource class is a
+        dependency for other resource classes.
+        """
+        self._auto_update['partition'] = \
+            self._needs_auto_update(mg_items_by_rc.get('partition'))
+        if not self._partitions:
+            self._setup_cpcs(mg_items_by_rc)
+            self._setup_storage_groups(mg_items_by_rc)
+            for cpc in self._all_cpc_list:
+                if not cpc.dpm_enabled:
+                    continue
+                logprint(
+                    logging.DEBUG, PRINT_VV,
+                    f"Listing partitions of DPM-mode CPC {cpc.name}")
+                # While listing, get the URI props for possibly exported
+                # element child objects into the cached resource
+                partitions = cpc.partitions.list(
+                    additional_properties=["nic-uris"])
+                for partition in partitions:
+                    self._add_partition(partition)
+
+    def _setup_nics(self, mg_items_by_rc):
+        """
+        Setup for resource class 'nic'.
+
+        This is called during setup() when metric groups for that resource
+        class are enabled for export, or when this resource class is a
+        dependency for other resource classes.
+        """
+        self._auto_update['nic'] = \
+            self._needs_auto_update(mg_items_by_rc.get('nic'))
+        if not self._nics:
+            self._setup_partitions(mg_items_by_rc)
+            self._setup_adapters(mg_items_by_rc)  # for backing adapters
+            self._setup_ports(mg_items_by_rc)  # for backing adapters
+            self._setup_vswitches(mg_items_by_rc)  # for backing adapters
+            for partition in self._all_partitions_by_id.values():
+                cpc = partition.manager.parent
+                logprint(
+                    logging.DEBUG, PRINT_VV,
+                    "Listing NICs of partition "
+                    f"{cpc.name}.{partition.name}")
+                nics = partition.nics.list()
+                for nic in nics:
+                    self._add_nic(nic)
+
+    def _setup_vswitches(self, mg_items_by_rc):
+        """
+        Setup for virtual switches.
+
+        This is not needed for metrics, but in order to identify the
+        backing adapters of NICs.
+
+        Only vswitches on the target CPCs are added.
+
+        This is called during setup() as a dependency for NIC setup.
+        """
+        if not self._vswitches:
+            self._setup_cpcs(mg_items_by_rc)
+            for cpc in self._target_cpc_list:
+                if 'network-express-support' not in \
+                        self._se_features_by_cpc[cpc.name]:
+                    logprint(
+                        logging.DEBUG, PRINT_VV,
+                        f"Listing vswitches of CPC {cpc.name}")
+                    vswitches = cpc.vswitches.list()
+                    for vswitch in vswitches:
+                        self._add_vswitch(vswitch)
+
+    def _setup_ports(self, mg_items_by_rc):
+        """
+        Setup for adapter ports.
+
+        This is not needed for metrics, but in order to identify the
+        backing adapters of NICs.
+
+        Only ports on the target CPCs are added.
+
+        This is called during setup() as a dependency for NIC setup.
+        """
+        if not self._ports:
+            self._setup_adapters(mg_items_by_rc)
+            for adapter in self._adapters.values():
+                net_ports = adapter.prop('network-port-uris')
+                if net_ports:
+                    cpc = adapter.manager.parent
+                    logprint(
+                        logging.DEBUG, PRINT_VV,
+                        "Listing ports of network adapter "
+                        f"{cpc.name}.{adapter.name}")
+                    ports = adapter.ports.list()
+                    for port in ports:
+                        self._add_port(port)
+
+    def _setup_storage_groups(self, mg_items_by_rc):
+        """
+        Setup for resource class 'storage-group'.
+
+        This is called during setup() when metric groups for that resource
+        class are enabled for export, or when this resource class is a
+        dependency for other resource classes.
+        """
+        self._auto_update['storage-group'] = \
+            self._needs_auto_update(mg_items_by_rc.get('storage-group'))
+        if not self._storage_groups:
+            self._setup_cpcs(mg_items_by_rc)
+            logprint(
+                logging.DEBUG, PRINT_VV,
+                "Listing storage groups")
+            # StorageGroupManager.list() does not support specifying
+            # additional properties (e.g. 'storage-volume-uris' )
+            storage_groups = self._console.storage_groups.list()
+            for sg in storage_groups:
+                self._add_storage_group(sg)
+
+    def _setup_storage_volumes(self, mg_items_by_rc):
+        """
+        Setup for resource class 'storage-volume'.
+
+        This is called during setup() when metric groups for that resource
+        class are enabled for export, or when this resource class is a
+        dependency for other resource classes.
+        """
+        self._auto_update['storage-volume'] = \
+            self._needs_auto_update(mg_items_by_rc.get('storage-volume'))
+        if not self._storage_volumes:
+            self._setup_storage_groups(mg_items_by_rc)
+            for sg in self._all_storage_groups_by_id.values():
+                logprint(
+                    logging.DEBUG, PRINT_VV,
+                    f"Listing volumes of storage group {sg.name}")
+                storage_volumes = sg.storage_volumes.list()
+                for sv in storage_volumes:
+                    self._add_storage_volume(sv)
+
+    def _add_cpc(self, cpc):
+        """
+        Add an accessible CPC to the cache.
+        """
+        self._all_resources_by_uri[cpc.uri] = cpc
+        if cpc in self._target_cpc_list:  # comparison by object ID
+            self._target_cpc_resources_by_id[id(cpc)] = cpc
+            self._cpcs[id(cpc)] = cpc
+            if self.is_auto_update('cpc'):
+                self._enable_auto_update(cpc, "CPC", cpc.name)
+
+    def _add_adapter(self, adapter):
+        """
+        Add an accessible adapter to the cache.
+        """
+        self._all_resources_by_uri[adapter.uri] = adapter
+        cpc = adapter.manager.parent
+        if cpc in self._target_cpc_list:  # comparison by object ID
+            self._target_cpc_resources_by_id[id(adapter)] = adapter
+            self._adapters[id(adapter)] = adapter
+            if self.is_auto_update('adapter'):
+                self._enable_auto_update(
+                    adapter, "adapter", f"{cpc.name}.{adapter.name}")
+
+    def _add_logical_partition(self, lpar):
+        """
+        Add an accessible LPAR to the cache.
+        """
+        self._all_resources_by_uri[lpar.uri] = lpar
+        cpc = lpar.manager.parent
+        if cpc in self._target_cpc_list:  # comparison by object ID
+            self._target_cpc_resources_by_id[id(lpar)] = lpar
+            self._logical_partitions[id(lpar)] = lpar
+            if self.is_auto_update('logical-partition'):
+                self._enable_auto_update(
+                    lpar, "LPAR", f"{cpc.name}.{lpar.name}")
+
+    def _add_partition(self, partition):
+        """
+        Add an accessible partition to the cache.
+        """
+        self._all_resources_by_uri[partition.uri] = partition
+        self._all_partitions_by_id[id(partition)] = partition
+        cpc = partition.manager.parent
+        if cpc in self._target_cpc_list:  # comparison by object ID
+            self._target_cpc_resources_by_id[id(partition)] = partition
+            self._partitions[id(partition)] = partition
+            if self.is_auto_update('partition'):
+                self._enable_auto_update(
+                    partition, "partition", f"{cpc.name}.{partition.name}")
+
+    def _add_nic(self, nic):
+        """
+        Add a NIC of an accessible partition to the cache.
+        """
+        self._all_resources_by_uri[nic.uri] = nic
+        partition = nic.manager.parent
+        cpc = partition.manager.parent
+        if cpc in self._target_cpc_list:  # comparison by object ID
+            self._target_cpc_resources_by_id[id(nic)] = nic
+            self._nics[id(nic)] = nic
+            if self.is_auto_update('nic'):
+                # Just for safety - there are no resource-based metric groups
+                # for NICs.
+                self._enable_auto_update(
+                    nic, "NIC", f"{cpc.name}.{partition.name}.{nic.name}")
+            else:
+                nic.pull_properties(
+                    ['name', 'virtual-switch-uri',
+                     'network-adapter-port-uri'])
+            # Add artificial attributes ot the Nic object
+            logprint(logging.INFO, PRINT_V,
+                     "Getting backing adapter port for NIC "
+                     f"{cpc.name}.{partition.name}.{nic.name}")
+            adapter_name, port_index = self._get_backing_adapter_info(nic)
+            nic.adapter_name = adapter_name
+            nic.port_index = port_index
+
+    def _add_vswitch(self, vswitch):
+        """
+        Add an accessible vswitch to the cache.
+        """
+        self._all_resources_by_uri[vswitch.uri] = vswitch
+        cpc = vswitch.manager.parent
+        if cpc in self._target_cpc_list:  # comparison by object ID
+            self._target_cpc_resources_by_id[id(vswitch)] = vswitch
+            self._vswitches[id(vswitch)] = vswitch
+
+    def _add_port(self, port):
+        """
+        Add a port of an accessible adapter to the cache.
+        """
+        self._all_resources_by_uri[port.uri] = port
+        adapter = port.manager.parent
+        cpc = adapter.manager.parent
+        if cpc in self._target_cpc_list:  # comparison by object ID
+            self._target_cpc_resources_by_id[id(port)] = port
+            self._ports[id(port)] = port
+
+    def _add_storage_group(self, sg):
+        """
+        Add an accessible storage group to the cache.
+        """
+        self._all_resources_by_uri[sg.uri] = sg
+        self._all_storage_groups_by_id[id(sg)] = sg
+        cpc_uri = sg.get_property('cpc-uri')
+        cpc = self._all_resources_by_uri[cpc_uri]
+        if cpc in self._target_cpc_list:  # comparison by object ID
+            self._target_cpc_resources_by_id[id(sg)] = sg
+            self._storage_groups[id(sg)] = sg
+            if self.is_auto_update('storage-group'):
+                self._enable_auto_update(
+                    sg, "storage group", f"{sg.name} (CPC {cpc.name})")
+
+    def _add_storage_volume(self, sv):
+        """
+        Add a storage volume of an accessible storage group to the cache.
+        """
+        self._all_resources_by_uri[sv.uri] = sv
+        sg = sv.manager.parent
+        cpc_uri = sg.get_property('cpc-uri')
+        cpc = self._all_resources_by_uri[cpc_uri]
+        if cpc in self._target_cpc_list:  # comparison by object ID
+            self._target_cpc_resources_by_id[id(sv)] = sv
+            self._storage_volumes[id(sv)] = sv
+            if self.is_auto_update('storage-volume'):
+                self._enable_auto_update(
+                    sv, "storage volume",
+                    f"{sg.name}.{sv.name} (CPC {cpc.name})")
+            else:
+                # Get the name of the element object into the cached
+                # resource object
+                sv.pull_properties(['name'])
+
+    def _add_inaccessible(self, uri):
+        """
+        Add an inaccessible object to the cache.
+        """
+        self._all_resources_by_uri[uri] = None  # Indicates inaccessible
+
+    def _get_backing_adapter_info(self, nic):
+        """
+        Return backing adapter and port of the specified NIC.
+
+        Parameters:
+          nic (zhmcclient.Nic): The NIC.
+
+        Returns:
+          tuple(adapter_name, port_index)
+        """
+        vswitch_uri = nic.prop('virtual-switch-uri')
+        if vswitch_uri:
+            # Handle vswitch-based NIC (OSA, HS before z17)
+            vswitch = self.lookup(vswitch_uri)
+            adapter_uri = vswitch.get_property('backing-adapter-uri')
+            adapter = self.lookup(adapter_uri)
+            port_index = vswitch.get_property('port')
+        else:
+            # Handle adapter-based NIC (RoCE, CNA before z17, all since z17)
+            port_uri = nic.get_property('network-adapter-port-uri')
+            port = self.lookup(port_uri)
+            adapter = port.manager.parent
+            port_index = port.get_property('index')
+        return adapter.name, port_index
+
+    def _setup_target_cpc_uri_list(self):
+        """
+        Setup the target CPC URI list, if not yet set up.
+        """
+        if self._target_cpc_uri_list is None:
+            self._target_cpc_uri_list = \
+                [cpc.uri for cpc in self._target_cpc_list]
+
+    @property
+    def resource_based_resources(self):
+        """
+        dict: The resources for resource-based metric groups that are enabled
+        for export.
+
+        * key (str): Metric group name
+        * value (list): List of zhmcclient.BaseResource
+        """
+        return self._resource_based_resources_by_mg
+
+    @property
+    def cpcs(self):
+        """
+        List view of zhmcclient.Cpc: The CPCs in the cache.
+        """
+        return self._cpcs.values()
+
+    @property
+    def adapters(self):
+        """
+        List view of zhmcclient.Adapter: The adapters in the cache.
+        """
+        return self._adapters.values()
+
+    @property
+    def logical_partitions(self):
+        """
+        List view of zhmcclient.LogicalPartition: The LPARs in the cache.
+        """
+        return self._logical_partitions.values()
+
+    @property
+    def partitions(self):
+        """
+        List view of zhmcclient.Partition: The partitions in the cache.
+        """
+        return self._partitions.values()
+
+    @property
+    def nics(self):
+        """
+        List view of zhmcclient.Nic: The NICs in the cache.
+        """
+        return self._nics.values()
+
+    @property
+    def storage_groups(self):
+        """
+        List view of zhmcclient.StorageGroup: The storage groups in the cache.
+        """
+        return self._storage_groups.values()
+
+    @property
+    def storage_volumes(self):
+        """
+        List view of zhmcclient.StorageVolume: The storage volumes in the cache.
+        """
+        return self._storage_volumes.values()
+
+    def setup(self):
+        """
+        Set up the cache with resources from the exported metric groups and
+        target CPCs.
+
+        The resources will be listed on the HMC and put into the cache.
+        Resources that are needed for resource-based metric groups will get
+        auto-enabled.
+        """
+
+        # Some methods check that so we set it right at the begin
+        self._setup_called = True
+
+        mg_items_by_rc = {}  # key: resource class, value: list of mg_items
+        for mg_name in self._exported_mg_names:
+            mg_item = self._mdf_metric_groups[mg_name]
+            resource_class = mg_item['resource_class']
+            if resource_class not in mg_items_by_rc:
+                mg_items_by_rc[resource_class] = []
+            mg_items_by_rc[resource_class].append(mg_item)
+
+        for resource_class in mg_items_by_rc:
+            # Note that vswitches and ports are not a resource of any metric
+            # group.
+            if resource_class == 'cpc':
+                self._setup_cpcs(mg_items_by_rc)
+            elif resource_class == 'adapter':
+                self._setup_adapters(mg_items_by_rc)
+            elif resource_class == 'logical-partition':
+                self._setup_logical_partitions(mg_items_by_rc)
+            elif resource_class == 'partition':
+                self._setup_partitions(mg_items_by_rc)
+            elif resource_class == 'nic':
+                self._setup_nics(mg_items_by_rc)
+            elif resource_class == 'storage-group':
+                self._setup_storage_groups(mg_items_by_rc)
+            elif resource_class == 'storage-volume':
+                self._setup_storage_volumes(mg_items_by_rc)
+            else:
+                new_exc = InvalidMetricDefinitionFile(
+                    f"Unknown resource class {resource_class} in a metric "
+                    f"group in the metric definition file.")
+                new_exc.__cause__ = None  # pylint: disable=invalid-name
+                raise new_exc
+
+        for mg_name in self._exported_mg_names:
+            mg_item = self._mdf_metric_groups[mg_name]
+            mg_type = mg_item['type']
+            resource_class = mg_item['resource_class']
+            if mg_type == "resource":
+                res_list = self._resource_id_dicts[resource_class].values()
+                self._resource_based_resources_by_mg[mg_name] = list(res_list)
+
+    def num_resources(self):
+        """
+        Return the number of all resources in the cache.
+        """
+        return len(self._all_resources_by_uri)
+
+    def cpc_from_resource(self, resource):
+        """
+        Return the CPC of the specified resource.
+
+        The CPC of a resource is one of:
+        - the resource itself, if it is a CPC.
+        - a direct or indirect parent of the resource.
+        - if the resource does not have a CPC parent but an associated CPC, the
+          associated CPC (for storage groups/volumes).
+
+        If the resource has no CPC, None is returned. This should not happen
+        for the resource classes currently supported by the resource cache.
+
+        The setup() method must have been called before calling this method.
+
+        Parameters:
+
+          resource (zhmcclient.BaseResource): The resource.
+
+        Returns:
+
+          zhmcclient.Cpc: The CPC of the resource, or None if the resource
+          does not have a CPC.
+        """
+        assert self._setup_called
+        if isinstance(resource, zhmcclient.StorageGroup):
+            # Storage groups are not children of CPCs
+            sg = resource
+            cpc_uri = sg.get_property('cpc-uri')
+            return self.lookup(cpc_uri)
+
+        if isinstance(resource, zhmcclient.StorageVolume):
+            # Storage groups are not children of CPCs
+            sv = resource
+            sg = sv.manager.parent
+            cpc_uri = sg.get_property('cpc-uri')
+            return self.lookup(cpc_uri)
+
+        # Assume the resource is a CPC or has one as a direct or indirect
+        # parent.
+        cpc = resource
+        while True:
+            if cpc is None or cpc.manager.class_name == 'cpc':
+                return cpc
+            cpc = cpc.manager.parent
+
+        return None  # Safe coding - this should never be reached
+
+    def is_for_target_cpc(self, resource):
+        """
+        Return boolean indicating that the specified resource is for a target
+        CPC.
+
+        This method is used to determine whether a metric returned by the HMC
+        metric service is for a target CPC.
+
+        The setup() method must have been called before calling this method.
+
+        Parameters:
+
+          resource (zhmcclient.BaseResource): The resource to be tested.
+            May be None (= inaccessible).
+
+        Return:
+
+          bool: Boolean indicating that the specified resource is for a target
+          CPC.
+        """
+        assert self._setup_called
+        return resource is not None and \
+            id(resource) in self._target_cpc_resources_by_id
+
+    def is_auto_update(self, resource_class):
+        """
+        Return boolean indicating that the specified resource class is enabled
+        for auto-update.
+
+        The setup() method must have been called before calling this method.
+
+        Parameters:
+
+          resource_class (str): The resource class to be tested.
+
+        Return:
+
+          bool: Boolean indicating that the specified resource class has metric
+          groups that are enabled for export.
+        """
+        assert self._setup_called
+        try:
+            return self._auto_update[resource_class]
+        except KeyError:
+            return False
+
+    def lookup(self, uri):
+        """
+        Look up the zhmcclient resource object for the specified URI in the
+        cache and return it.
+
+        If the resource URI cannot be found in the cache, the resource is
+        retrieved from the HMC.
+
+        If the resource URI cannot be found on the HMC, `NotFound` is raised.
+        Note that missing object access permissions may be a reason for that.
+
+        The setup() method must have been called before calling this method.
+
+        Parameters:
+
+          uri (str): URI of the resource.
+
+        Returns:
+
+          zhmcclient.BaseResource: zhmcclient resource object.
+
+        Raises:
+
+          zhmcclient.NotFound: The resource URI is not found on the HMC.
+        """
+        assert self._setup_called
+        try:
+            return self._all_resources_by_uri[uri]
+        except KeyError:
+            return self.add(uri)
+
+    def _get_resource_tolerant(self, uri):
+        """
+        Perform a "Get <resource> Properties" operation on the HMC for the
+        specified URI and return the resulting resource properties.
+
+        If the URI cannot be found, we assume it is because of missing object
+        access permissions. In that case, None is returned.
+
+        Parameters:
+
+          uri (str): URI of the resource.
+
+        Returns:
+
+          dict: Properties of the resource, or None if the resource cannot be
+          found on the HMC.
+
+        Raises:
+
+          Other zhmcclient exceptions
         """
         try:
-            _resource = self._resources[uri]
-        except KeyError:
-            logprint(logging.INFO, PRINT_VV,
-                     f"Finding resource for {uri}")
-            try:
-                _resource = object_value.resource  # Takes time to find on HMC
-            except zhmcclient.MetricsResourceNotFound as exc:
-                mgd = object_value.metric_group_definition
-                logprint(logging.WARNING, PRINT_ALWAYS,
-                         f"Did not find resource {uri} specified in metric "
-                         f"object value for metric group '{mgd.name}'")
-                DISPLAY_CACHE = False
-                if DISPLAY_CACHE:
-                    for mgr in exc.managers:
-                        res_class = mgr.class_name
-                        logprint(logging.WARNING, PRINT_ALWAYS,
-                                 f"Details: List of {res_class} resources "
-                                 "found:")
-                        for res in mgr.list():
-                            logprint(logging.WARNING, PRINT_ALWAYS,
-                                     f"Details: Resource found: {res.uri} "
-                                     f"({res.name})")
-                    logprint(logging.WARNING, PRINT_ALWAYS,
-                             "Details: Current resource cache:")
-                    for res in self._resources.values():
-                        logprint(logging.WARNING, PRINT_ALWAYS,
-                                 f"Details: Resource cache: {res.uri} "
-                                 f"({res.name})")
-                raise
-            self._resources[uri] = _resource
-        return _resource
+            props = self._session.get(uri)
+        except zhmcclient.HTTPError as exc:
+            if exc.http_status == 404 and exc.reason == 1:
+                return None
+            raise
+        return props
+
+    def add(self, uri):
+        """
+        Find a resource on the HMC and add its zhmcclient resource object to
+        the cache.
+
+        If the URI cannot be found on the HMC, NotFound is raised.
+        Note that missing object access permissions may be a reason for that.
+
+        The caller must ensure that the URI is for one of the resource classes
+        supported by the cache because the use of the URI is optimized for
+        performance and invalid resource classes are not fully detected by this
+        method.
+
+        The setup() method must have been called before calling this method.
+
+        Parameters:
+
+          uri (str): URI of the resource.
+
+        Returns:
+
+          zhmcclient.BaseResource: zhmcclient resource object.
+
+        Raises:
+          zhmcclient.NotFound: The resource URI is not found on the HMC.
+        """
+        assert self._setup_called
+        self._setup_target_cpc_uri_list()
+
+        # The order of URI tests is by decreasing number of resources, so it is
+        # optimitzed for the initial setup.
+
+        m = re.match(
+            r'(/api/storage-groups/[a-f0-9\-]+)/storage-volumes/[a-f0-9\-]+$',
+            uri)
+        if m:
+            # A new storage volume
+            sg_uri = m.group(1)
+            sg = self.lookup(sg_uri)  # adds if needed
+            if sg is None:
+                self._add_inaccessible(uri)
+                return None
+            sv = sg.storage_volumes.resource_object(uri)
+            self._add_storage_volume(sv)
+            return sv
+
+        m = re.match(r'/api/storage-groups/[a-f0-9\-]+$', uri)
+        if m:
+            # A new storage group
+            # Storage groups have access permissions, so we check access.
+            sg_get_uri = f"{uri}?properties=name,cpc-uri"
+            sg_props = self._get_resource_tolerant(sg_get_uri)
+            if sg_props is None:
+                self._add_inaccessible(uri)
+                return None
+            sg = self._console.storage_groups.resource_object(uri, sg_props)
+            self._add_storage_group(sg)
+            return sg
+
+        m = re.match(r'(/api/partitions/[a-f0-9\-]+)/nics/[a-f0-9\-]+$', uri)
+        if m:
+            # A new NIC
+            part_uri = m.group(1)
+            part = self.lookup(part_uri)  # adds if needed
+            if part is None:
+                self._add_inaccessible(uri)
+                return None
+            nic = part.nics.resource_object(uri)
+            self._add_nic(nic)
+            return nic
+
+        m = re.match(r'/api/partitions/[a-f0-9\-]+$', uri)
+        if m:
+            # A new partition
+            # Partitions have access permissions, so we check access.
+            part_get_uri = f"{uri}?properties=name,parent"
+            part_props = self._get_resource_tolerant(part_get_uri)
+            if part_props is None:
+                self._add_inaccessible(uri)
+                return None
+            cpc_uri = part_props['parent']
+            cpc = self._all_resources_by_uri[cpc_uri]
+            part = cpc.partitions.resource_object(uri, part_props)
+            self._add_partition(part)
+            return part
+
+        m = re.match(r'/api/logical-partitions/[a-f0-9\-]+$', uri)
+        if m:
+            # A new LPAR
+            # LPARs have access permissions, so we check access.
+            lpar_get_uri = f"{uri}?properties=name,parent"
+            lpar_props = self._get_resource_tolerant(lpar_get_uri)
+            if lpar_props is None:
+                self._add_inaccessible(uri)
+                return None
+            cpc_uri = lpar_props['parent']
+            cpc = self._all_resources_by_uri[cpc_uri]
+            lpar = cpc.lpars.resource_object(uri, lpar_props)
+            self._add_logical_partition(lpar)
+            return lpar
+
+        m = re.match(r'/api/adapters/[a-f0-9\-]+$', uri)
+        if m:
+            # A new adapter
+            # Adapters have access permissions, so we check access.
+            # "Get Adapter Properties" does not support property selection
+            ad_props = self._get_resource_tolerant(uri)
+            if ad_props is None:
+                self._add_inaccessible(uri)
+                return None
+            cpc_uri = ad_props['parent']
+            cpc = self._all_resources_by_uri[cpc_uri]
+            ad = cpc.adapters.resource_object(uri, ad_props)
+            self._add_adapter(ad)
+            return ad
+
+        m = re.match(
+            r'(/api/adapters/[a-f0-9\-]+)/(network|storage)-ports/[a-f0-9\-]+$',
+            uri)
+        if m:
+            # A new network or storage port
+            adapter_uri = m.group(1)
+            ad = self.lookup(adapter_uri)  # adds if needed
+            if ad is None:
+                self._add_inaccessible(uri)
+                return None
+            port = ad.ports.resource_object(uri)
+            self._add_port(port)
+            return port
+
+        m = re.match(
+            r'(/api/cpcs/[a-f0-9\-]+)/virtual-switches/[a-f0-9\-]+$', uri)
+        if m:
+            # A new vswitch
+            # Vswitches use the access permissions of the backing adapter, so
+            # we check access.
+            # "Get V. Switch Properties" does not support property selection
+            vswitch_props = self._get_resource_tolerant(uri)
+            if vswitch_props is None:
+                self._add_inaccessible(uri)
+                return None
+            cpc_uri = m.group(1)
+            cpc = self.lookup(cpc_uri)  # adds if needed
+            vswitch = cpc.vswitches.resource_object(uri, vswitch_props)
+            self._add_vswitch(vswitch)
+            return vswitch
+
+        m = re.match(r'/api/cpcs/[a-f0-9\-]+$', uri)
+        if m:
+            # A new CPC
+            # CPCs have access permissions, so we check access.
+            cpc_get_uri = f"{uri}?properties=name"
+            cpc_props = self._get_resource_tolerant(cpc_get_uri)
+            if cpc_props is None:
+                self._add_inaccessible(uri)
+                return None
+            cpc = self._client.cpcs.resource_object(uri, cpc_props)
+            self._add_cpc(cpc)
+            return cpc
+
+        raise ValueError(f"Invalid resource class in URI: {uri}")
 
     def remove(self, uri):
         """
-        Remove the resource with a specified URI from the cache, if present.
-        If not present, nothing happens.
+        Remove a resource from the cache.
+
+        This is used when resources are deleted on the HMC. The cache itself
+        does not recognize that, so it needs to be told from the outside.
+
+        If the cache does not have a resource for the specified URI, this is
+        ignored.
+
+        The setup() method must have been called before calling this method.
+
+        Parameters:
+
+          uri (str): URI of the resource.
         """
+        assert self._setup_called
+        res_id_dict = self._resource_id_dict(uri)
         try:
-            del self._resources[uri]
+            res = self._all_resources_by_uri[uri]
+            del self._all_resources_by_uri[uri]
+            del self._target_cpc_resources_by_id[id(res)]
+            if res_id_dict is self._storage_groups:
+                del self._all_storage_groups_by_id[id(res)]
+            if res_id_dict is self._partitions:
+                del self._all_partitions_by_id[id(res)]
+            del res_id_dict[id(res)]
         except KeyError:
-            pass
+            logprint(logging.ERROR, None,
+                     "Ignored failure when removing a resource from the cache: "
+                     f"URI not found in one of the cache properties: '{uri}'")

--- a/zhmc_prometheus_exporter/data/metrics.yaml
+++ b/zhmc_prometheus_exporter/data/metrics.yaml
@@ -7,14 +7,18 @@ metric_groups:
   # Available for CPCs in classic mode
 
   cpc-usage-overview:
+    cpc_mode: classic
     type: metric
+    resource_class: cpc
     prefix: cpc
     labels:
       - name: cpc
         value: "resource_obj.name"
 
   logical-partition-usage:
+    cpc_mode: classic
     type: metric
+    resource_class: logical-partition
     prefix: partition
     labels:
       - name: cpc
@@ -23,7 +27,9 @@ metric_groups:
         value: "resource_obj.name"
 
   channel-usage:
+    cpc_mode: classic
     type: metric
+    resource_class: cpc
     prefix: channel
     labels:
       - name: cpc
@@ -32,7 +38,9 @@ metric_groups:
         value: "metric_values['channel-name']"  # format: 'CSS.CHPID'
 
   crypto-usage:
+    cpc_mode: classic
     type: metric
+    resource_class: cpc
     prefix: crypto_adapter
     if: "hmc_version>='2.12.0'"
     labels:
@@ -42,7 +50,9 @@ metric_groups:
         value: "metric_values['channel-id']"
 
   flash-memory-usage:
+    cpc_mode: classic
     type: metric
+    resource_class: cpc
     prefix: flash_memory_adapter
     if: "hmc_version>='2.12.0'"
     labels:
@@ -52,7 +62,9 @@ metric_groups:
         value: "metric_values['channel-id']"
 
   roce-usage:
+    cpc_mode: classic
     type: metric
+    resource_class: cpc
     prefix: roce_adapter
     if: "hmc_version>='2.12.1'"
     labels:
@@ -62,8 +74,9 @@ metric_groups:
         value: "metric_values['channel-id']"
 
   logical-partition-resource:
+    cpc_mode: classic
     type: resource
-    resource: cpc.logical-partition
+    resource_class: logical-partition
     prefix: partition
     labels:
       - name: cpc
@@ -74,7 +87,9 @@ metric_groups:
   # Available for CPCs in DPM mode
 
   dpm-system-usage-overview:
+    cpc_mode: dpm
     type: metric
+    resource_class: cpc
     prefix: cpc
     if: "hmc_version>='2.13.1'"
     labels:
@@ -82,7 +97,9 @@ metric_groups:
         value: "resource_obj.name"
 
   partition-usage:
+    cpc_mode: dpm
     type: metric
+    resource_class: partition
     prefix: partition
     if: "hmc_version>='2.13.1'"
     labels:
@@ -92,7 +109,9 @@ metric_groups:
         value: "resource_obj.name"
 
   adapter-usage:
+    cpc_mode: dpm
     type: metric
+    resource_class: adapter
     prefix: adapter
     if: "hmc_version>='2.13.1'"
     labels:
@@ -102,7 +121,9 @@ metric_groups:
         value: "resource_obj.name"
 
   network-physical-adapter-port:
+    cpc_mode: dpm
     type: metric
+    resource_class: adapter
     prefix: port
     if: "hmc_version>='2.13.1'"
     labels:
@@ -114,7 +135,9 @@ metric_groups:
         value: "metric_values['network-port-id']"
 
   partition-attached-network-interface:
+    cpc_mode: dpm
     type: metric
+    resource_class: nic
     prefix: nic
     if: "hmc_version>='2.13.1'"
     labels:
@@ -130,8 +153,9 @@ metric_groups:
         value: "adapter_port(resource_obj)"
 
   partition-resource:
+    cpc_mode: dpm
     type: resource
-    resource: cpc.partition
+    resource_class: partition
     prefix: partition
     if: "hmc_version>='2.13.1'"
     labels:
@@ -141,8 +165,9 @@ metric_groups:
         value: "resource_obj.name"
 
   storagegroup-resource:
+    cpc_mode: dpm
     type: resource
-    resource: console.storagegroup
+    resource_class: storage-group
     prefix: storagegroup
     if: "hmc_version>='2.14.1'"
     labels:
@@ -152,8 +177,9 @@ metric_groups:
         value: "resource_obj.name"
 
   storagevolume-resource:
+    cpc_mode: dpm
     type: resource
-    resource: console.storagevolume
+    resource_class: storage-volume
     prefix: storagevolume
     if: "hmc_version>='2.14.1'"
     labels:
@@ -165,8 +191,9 @@ metric_groups:
         value: "resource_obj.name"
 
   adapter-resource:
+    cpc_mode: dpm
     type: resource
-    resource: cpc.adapter
+    resource_class: adapter
     prefix: adapter
     if: "hmc_version>='2.13.1'"
     labels:
@@ -178,14 +205,18 @@ metric_groups:
   # Available for CPCs in any mode
 
   zcpc-environmentals-and-power:
+    cpc_mode: any
     type: metric
+    resource_class: cpc
     prefix: cpc
     labels:
       - name: cpc
         value: "resource_obj.name"
 
   zcpc-processor-usage:
+    cpc_mode: any
     type: metric
+    resource_class: cpc
     prefix: processor
     labels:
       - name: cpc
@@ -196,7 +227,9 @@ metric_groups:
         value: "metric_values['processor-type']"
 
   environmental-power-status:
+    cpc_mode: any
     type: metric
+    resource_class: cpc
     prefix: cpc
     if: "hmc_version>='2.15.0'"
     labels:
@@ -204,8 +237,9 @@ metric_groups:
         value: "resource_obj.name"
 
   cpc-resource:
+    cpc_mode: any
     type: resource
-    resource: cpc
+    resource_class: cpc
     prefix: cpc
     labels:
       - name: cpc

--- a/zhmc_prometheus_exporter/schemas/metrics_schema.yaml
+++ b/zhmc_prometheus_exporter/schemas/metrics_schema.yaml
@@ -18,17 +18,24 @@ properties:
         description: "Key: Name of the HMC or resource metric group"
         type: object
         required:
+          - cpc_mode
           - type
+          - resource_class
           - prefix
         additionalProperties: false
         properties:
+          cpc_mode:
+            description: "The operational mode of the CPC for which this metric group is supported."
+            type: string
+            enum: [classic, dpm, any]
           type:
             description: "The type of metric group: metric - an HMC metric group in which the metric values come from the HMC metric service; resource - an artificial metric group in which the metric values come from resource properties."
             type: string
             enum: [metric, resource]
-          resource:
-            description: "The resource class path for a resource metric group, starting at the zhmcclient.Client object (e.g. 'cpc.partition')."
+          resource_class:
+            description: "The resource class for the resources the metrics in the metric group are about."
             type: string
+            enum: [cpc, adapter, logical-partition, partition, nic, storage-group, storage-volume]
           prefix:
             description: "<prefix> part of Prometheus metric name (format: zhmc_<prefix>_<metric_unit>)"
             type: string


### PR DESCRIPTION
For details, see the commit message.
Ready for review.

Tests with missing access permissions was moved to a new issue #788.

Here is a distribution archive for that code level. You can install this version by downloading the file, and (important!) renaming it from `.zip` to `.whl`, and then installing it using `pip install <filename>`:
[zhmc_prometheus_exporter-2.1.1.dev7+g2163b5eba-py3-none-any.zip](https://github.com/user-attachments/files/22049419/zhmc_prometheus_exporter-2.1.1.dev7%2Bg2163b5eba-py3-none-any.zip)