### PR TITLE
2.2: Removed the pinning on typer version <0.17.0 with safety 3.6.1

### DIFF
--- a/changes/noissue.68.fix.rst
+++ b/changes/noissue.68.fix.rst
@@ -1,0 +1,2 @@
+Removed the pinning of typer version to <0.17.0 with the new release of safety 3.6.1 and
+also upgraded minimum version of safety to be 3.6.1 to fix the issue with typer>=0.17.0, see  https://github.com/pyupio/safety/issues/778

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -17,10 +17,9 @@ pyproject-hooks>=1.1.0
 towncrier>=22.8.0
 
 # Safety CI by pyup.io
-# safety 3.4.0 supports marshmallow>=4.0.0, see https://github.com/pyupio/safety/issues/715
-# safety 3.4.0 started using httpx and tenacity
+# safety 3.6.1 fixes the issue with typer >=0.17.0, see https://github.com/pyupio/safety/issues/778
 # pydantic 2.8.0 fixes an install issue on Python 3.13.
-safety>=3.4.0
+safety>=3.6.1
 safety-schemas>=0.0.14
 dparse>=0.6.4
 # ruamel.yaml is used by safety and is covered in requirements.txt
@@ -28,10 +27,10 @@ click>=8.0.2
 Authlib>=1.3.1
 marshmallow>=3.15.0
 pydantic>=2.8.0
-# typer >=0.17.0 causes import issue for safety, see https://github.com/pyupio/safety/issues/778
-typer>=0.12.1,<0.17.0
-typer-cli>=0.12.1,<0.17.0
-typer-slim>=0.12.1,<0.17.0
+#safety 3.6.1 depends on typer>=0.16.0
+typer>=0.16.0
+typer-cli>=0.16.0
+typer-slim>=0.16.0
 # safety 3.4.0 depends on psutil~=6.1.0
 psutil~=6.1.0
 

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -16,7 +16,7 @@ incremental==22.10.0
 click-default-group==1.2.4
 
 # Safety CI by pyup.io
-safety==3.4.0
+safety==3.6.1
 safety-schemas==0.0.14
 dparse==0.6.4
 # ruamel.yaml is used by safety and is covered in minimum-constraints-install.txt
@@ -24,9 +24,9 @@ click==8.0.2
 Authlib==1.3.1
 marshmallow==3.15.0
 pydantic==2.8.0
-typer==0.12.1
-typer-cli==0.12.1
-typer-slim==0.12.1
+typer==0.16.0
+typer-cli==0.16.0
+typer-slim==0.16.0
 psutil==6.1.0
 
 # Bandit checker


### PR DESCRIPTION
Rolls back PR #800 into 2.2.