### PR TITLE
Upgrade nltk to make it compatible with safety 3.6.1

### DIFF
--- a/changes/noissue.92.fix.rst
+++ b/changes/noissue.92.fix.rst
@@ -1,0 +1,1 @@
+Upgrade nltk to 3.9.1 to fix the wordnet error, see https://github.com/nltk/nltk/issues/3416

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -117,7 +117,7 @@ iniconfig==1.1.1  # used by pytest since its 6.0.0
 keyring==18.0.0
 levenshtein==0.25.1
 more-itertools==8.0.0
-nltk==3.9
+nltk==3.9.1
 pkginfo==1.4.2
 pyparsing==2.4.5
 requests-toolbelt==0.8.0


### PR DESCRIPTION
* Upgrade nltk to 3.9.1 to fix the wordnet error