### PR TITLE
Configure HMC request/response data in logs to no longer be truncated

### DIFF
--- a/changes/807.2.feature.rst
+++ b/changes/807.2.feature.rst
@@ -1,0 +1,1 @@
+Increased zhmcclient version to 1.24.0 to pick up fixes and functionality.

--- a/changes/807.feature.rst
+++ b/changes/807.feature.rst
@@ -1,0 +1,1 @@
+Configure HMC request/response data in logs to no longer be truncated.

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -19,7 +19,7 @@ wheel==0.41.3
 
 # Direct dependencies for install (must be consistent with requirements.txt)
 
-zhmcclient==1.23.1
+zhmcclient==1.24.0
 
 # TODO: Use official prometheus-client version (0.21.0 ?) once released.
 # prometheus-client==0.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,8 @@
 
 # Direct dependencies for install (must be consistent with minimum-constraints-install.txt)
 
+zhmcclient>=1.24.0
 # zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
-zhmcclient>=1.23.1
 
 # prometheus-client 0.19.0 added support for HTTPS/mTLS
 # prometheus-client 0.20.0 improved HTTPS/mTLS support

--- a/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
+++ b/zhmc_prometheus_exporter/zhmc_prometheus_exporter.py
@@ -64,6 +64,9 @@ FETCH_HYSTERESIS = 10
 # Sleep time in seconds when retrying metrics retrieval
 RETRY_SLEEP_TIME = 10
 
+# HMC request/response truncation of data in log entries. 0 means no truncation.
+LOG_CONTENT_TRUNCATE = 0
+
 
 def parse_args(args):
     """Parses the CLI arguments."""
@@ -703,6 +706,7 @@ def create_session(config_dict, config_filename):
         status_timeout=rt_parms.get(
             "status_timeout", zhmcclient.DEFAULT_STATUS_TIMEOUT),
         name_uri_cache_timetolive=zhmcclient.DEFAULT_NAME_URI_CACHE_TIMETOLIVE,
+        log_content_truncate=LOG_CONTENT_TRUNCATE,
     )
 
     logprint(logging.INFO, PRINT_V,
@@ -711,6 +715,11 @@ def create_session(config_dict, config_filename):
              f"{rt_config.connect_retries} retries, "
              f"read: {rt_config.read_timeout} sec / "
              f"{rt_config.read_retries} retries.")
+
+    truncate_str = f"{rt_config.log_content_truncate} B" if \
+        rt_config.log_content_truncate > 0 else 'none'
+    logprint(logging.INFO, PRINT_V,
+             f"Log truncation: {truncate_str}")
 
     session = zhmcclient.Session(hmc_dict["host"],
                                  hmc_dict["userid"],


### PR DESCRIPTION
Ready for review.

Tested on HMC of AHPS etc.