### PR TITLE
Fixed HTTP 400,1 when listing partitions

### DIFF
--- a/changes/823.fix.rst
+++ b/changes/823.fix.rst
@@ -1,0 +1,2 @@
+Fixed an HTTP 400,1 error when listing partitions of a CPC in DPM mode on
+a HMC version 2.15.

--- a/zhmc_prometheus_exporter/_resource_cache.py
+++ b/zhmc_prometheus_exporter/_resource_cache.py
@@ -430,8 +430,11 @@ class ResourceCache:
                     f"Listing partitions of DPM-mode CPC {cpc.name}")
                 # While listing, get the URI props for possibly exported
                 # element child objects into the cached resource
-                partitions = cpc.partitions.list(
-                    additional_properties=["nic-uris"])
+                if self._client.version_info() >= (4, 1):
+                    partitions = cpc.partitions.list(
+                        additional_properties=["nic-uris"])
+                else:
+                    partitions = cpc.partitions.list()
                 for partition in partitions:
                     self._add_partition(partition)
 


### PR DESCRIPTION
For details, see the commit message.

Tested the change on T218, where the original error appeared.