### PR TITLE
2.3: Git-ignored docs/tmp_changes.rst

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ __pycache__/
 
 # Make build_doc
 /build_docs/
+/docs/tmp_changes.rst
 
 # Other
 *.swp


### PR DESCRIPTION
Rolls back PR #832 into 2.3.