### PR TITLE
Used new license format defined in PEP 639

### DIFF
--- a/changes/839.cleanup.rst
+++ b/changes/839.cleanup.rst
@@ -1,0 +1,2 @@
+Used new license format defined in PEP 639 to accommodate upcoming removal
+of support for old format.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -52,7 +52,7 @@ colorama>=0.4.6
 pluggy>=1.5.0
 
 # packaging is used by pytest, pip-check-reqs, sphinx
-packaging>=24.1
+packaging>=24.2
 
 # Coverage reporting (no imports, invoked via coveralls script):
 # coveralls versions 4.0.0/4.0.1 have increased their pinning of coverage to <8,

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -40,7 +40,7 @@ pluggy==1.5.0
 importlib-metadata==8.7.0
 colorama==0.4.6
 
-packaging==24.1
+packaging==24.2
 
 # Coverage reporting (no imports, invoked via coveralls script):
 coverage==7.8.0; python_version <= '3.12'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,10 +53,11 @@ maintainers = [
 ]
 
 readme = "README.md"
-license = {text = "Apache License, Version 2.0"}
+# License info in new PEP 639 format (since setuptools 77.0.3)
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 keywords = ["hmc", "prometheus", "monitoring"]
 classifiers = [
-    "License :: OSI Approved :: Apache Software License",
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Information Technology",
     "Topic :: System :: Systems Administration",


### PR DESCRIPTION
For details, see the commit message.
Cannot be rolled back because it requires Python>=3.9, and we don't drop Python versions in a fix release.
No review needed.