### PR TITLE
Added support for automatically detecting newly created resources on the HMC

### DIFF
--- a/changes/227.feature.rst
+++ b/changes/227.feature.rst
@@ -1,0 +1,5 @@
+Added support for automatically detecting newly created resources on the HMC
+so their resource-based metrics are automatically added the list of exported
+metrics. Note that newly deleted resources on the HMC were already
+automatically removed from the list of exported resource-based metrics since
+version 1.3.0.

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -19,7 +19,9 @@ wheel==0.41.3
 
 # Direct dependencies for install (must be consistent with requirements.txt)
 
-zhmcclient==1.24.0
+# TODO(ZHMC): Enable again once zhmcclient 1.26.0 has been released
+# zhmcclient>=1.26.0
+zhmcclient@git+https://github.com/zhmcclient/python-zhmcclient.git@master
 
 # TODO: Use official prometheus-client version (0.21.0 ?) once released.
 # prometheus-client==0.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,9 @@
 
 # Direct dependencies for install (must be consistent with minimum-constraints-install.txt)
 
-zhmcclient>=1.24.0
-# zhmcclient @ git+https://github.com/zhmcclient/python-zhmcclient.git@master
+# TODO(ZHMC): Enable again once zhmcclient 1.26.0 has been released
+# zhmcclient>=1.26.0
+zhmcclient@git+https://github.com/zhmcclient/python-zhmcclient.git@master
 
 # prometheus-client 0.19.0 added support for HTTPS/mTLS
 # prometheus-client 0.20.0 improved HTTPS/mTLS support

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -484,6 +484,7 @@ class TestMetrics(unittest.TestCase):
         resource_cache = ResourceCache(
             client, cpc_list, cpc_list, yaml_metric_groups, exported_mg_names,
             se_features_by_cpc)
+        resource_cache.prepare()
         resource_cache.setup()  # from mocked env
 
         metrics_object = zhmc_prometheus_exporter.retrieve_metrics(context)
@@ -613,6 +614,7 @@ class TestInitZHMCUsageCollector(unittest.TestCase):
         resource_cache = ResourceCache(
             client, cpc_list, cpc_list, yaml_metric_groups, exported_mg_names,
             se_features_by_cpc)
+        resource_cache.prepare()
         resource_cache.setup()  # from mocked env
 
         my_zhmc_usage_collector = zhmc_prometheus_exporter.ZHMCUsageCollector(
@@ -704,6 +706,7 @@ class TestInitZHMCUsageCollector(unittest.TestCase):
         resource_cache = ResourceCache(
             client, cpc_list, cpc_list, yaml_metric_groups, exported_mg_names,
             se_features_by_cpc)
+        resource_cache.prepare()
         resource_cache.setup()  # from mocked env
 
         my_zhmc_usage_collector = zhmc_prometheus_exporter.ZHMCUsageCollector(


### PR DESCRIPTION
For details, see the commit message.

I tested this PR with a browser against A224:
* When enabling all metric groups, the same data was shown as before this change.
* When enabling just metric groups "partition-usage" and "partition-resource":
  - adding and removing partitions on the HMC caused them to be added and removed correctly when updating the browser. The metric-type "partition-usage" group required that the partitions were active, and I used SSC partitions which can easily be started in installer mode (after adding an SSC mgmt NIC).
  - Added a NIC early in the process when the setup() method had not yet pulled the resources to populate the cache. This test was achieved by setting a breakpoint just before setup() is called, and adding a NIC to an existing partition.

Minimal commands for creating an active SSC partition:
```
$ zhmc partition create A224 --name test3 --type ssc --initial-memory 4096 --maximum-memory 4096 --ssc-host-name test1 --ssc-master-userid user --ssc-master-pw passw0rd
New partition 'test3' has been created.
$ zhmc nic create A224 test3 --name nic1 --ssc-management-nic true --adapter MGMT1 --port 0 --ssc-ip-address-type dhcp
New NIC 'nic1' has been created.
$ zhmc partition start A224 test3
Partition 'test3' has been started.
```