### PR TITLE
Improved reporting of errors in 'make doclinkcheck' in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -271,7 +271,6 @@ jobs:
         RUN_TYPE: ${{ steps.set-run-type.outputs.result }}
       run: |
         make doclinkcheck
-      continue-on-error: true
 
   test_finish:
     needs: test

--- a/Makefile
+++ b/Makefile
@@ -372,7 +372,7 @@ all: install develop check_reqs check ruff pylint test build builddoc check_reqs
 .PHONY: doclinkcheck
 doclinkcheck: $(done_dir)/develop_$(pymn)_$(PACKAGE_LEVEL).done
 	@echo "Running Sphinx to check doc links"
-	sphinx-build -b linkcheck -v $(doc_dir) $(doc_build_dir)/linkcheck
+	@bash -c 'sphinx-build -b linkcheck -v $(doc_dir) $(doc_build_dir)/linkcheck; rc=$$?; if [ $$rc -ne 0 ]; then echo "::notice::doclinkcheck failed (ignored)"; fi'
 	@echo "Done: Look for any errors in the above output or in: $(doc_build_dir)/linkcheck/output.txt"
 	@echo "Makefile: $@ done."
 


### PR DESCRIPTION
For details, see the commit message.

For the changed appearance in GitHub Actions, look at the annotations in the actions summary of this PR and compare it with prior PRs (Click on any of the checks of this PR -> Click on "Summary").