### PR TITLE
Added missing dependency for defusedxml (needed by nltk>=3.10)

### DIFF
--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -102,6 +102,8 @@ backports-datetime-fromisoformat==2.0.3
 cffi==2.0.0
 commonmark==0.9.2
 cryptography==49.0.0
+# defusedxml is used by nltk>=3.10.0
+defusedxml==0.7.1; python_version >= '3.10'
 distlib==0.4.3
 exceptiongroup==1.3.1
 filelock==3.16.1; python_version <= '3.9'


### PR DESCRIPTION
No review needed.