### PR TITLE
Fixed pip-missing-reqs TypeError by pinning pip to <26.2

### DIFF
--- a/changes/noissue.pipcheckreqs.fix.rst
+++ b/changes/noissue.pipcheckreqs.fix.rst
@@ -1,0 +1,2 @@
+Development: Fixed that pip-missing-reqs raised TypeError by pinning pip
+to <26.2.

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -89,7 +89,7 @@ roman-numerals==4.1.0
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree==2.24.0
-pip-check-reqs==2.5.1
+pip-check-reqs==2.5.6
 
 
 # Indirect dependencies for development that are not in requirements-develop.txt

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -6,7 +6,8 @@
 # and build-system.requires in pyproject.toml)
 
 pip>=26.0.1; python_version == '3.9'
-pip>=26.1.2; python_version >= '3.10'
+# Pinning pip to <26.2 is a quick fix to circumvent https://github.com/adamtheturtle/pip-check-reqs/issues/570
+pip>=26.1.2,<26.2; python_version >= '3.10'
 setuptools>=78.1.1
 setuptools-scm[toml]>=9.2.0
 wheel>=0.46.2

--- a/requirements-develop.txt
+++ b/requirements-develop.txt
@@ -95,4 +95,7 @@ Babel>=2.12.0
 
 # Package dependency management tools (not used by any make rules)
 pipdeptree>=2.24.0
-pip-check-reqs>=2.5.1
+pip-check-reqs>=2.5.6
+
+# Pinning pip to <26.2 is a quick fix to circumvent https://github.com/adamtheturtle/pip-check-reqs/issues/570
+pip>=26.1.2,<26.2; python_version >= '3.10'


### PR DESCRIPTION
No review needed.