### PR TITLE
2.3: Fixed pip-missing-reqs TypeError by pinning pip to <26.2

### DIFF
--- a/base-requirements.txt
+++ b/base-requirements.txt
@@ -7,7 +7,8 @@
 
 pip>=25.0; python_version == '3.8'
 pip>=26.0.1; python_version == '3.9'
-pip>=26.1; python_version >= '3.10'
+# Pinning pip to <26.2 is a quick fix to circumvent https://github.com/adamtheturtle/pip-check-reqs/issues/570
+pip>=26.1.2,<26.2; python_version >= '3.10'
 setuptools>=70.0.0; python_version == '3.8'
 setuptools>=78.1.1; python_version >= '3.9'
 setuptools-scm[toml]>=9.2.0

--- a/changes/noissue.pipcheckreqs.fix.rst
+++ b/changes/noissue.pipcheckreqs.fix.rst
@@ -1,0 +1,2 @@
+Development: Fixed that pip-missing-reqs raised TypeError by pinning pip
+to <26.2.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -123,4 +123,7 @@ pipdeptree>=2.24.0
 # pip-check-reqs 2.5.0 dropped support for py38
 # pip-check-reqs 2.5.0 has issue https://github.com/r1chardj0n3s/pip-check-reqs/issues/143
 pip-check-reqs>=2.4.3,!=2.5.0; python_version == '3.8'
-pip-check-reqs>=2.5.1; python_version >= '3.9'
+pip-check-reqs>=2.5.6; python_version >= '3.9'
+
+# Pinning pip to <26.2 is a quick fix to circumvent https://github.com/adamtheturtle/pip-check-reqs/issues/570
+pip>=26.1.2,<26.2; python_version >= '3.10'

--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -110,7 +110,7 @@ roman-numerals==4.1.0
 # Package dependency management tools (not used by any make rules)
 pipdeptree==2.24.0
 pip-check-reqs==2.4.3; python_version == '3.8'
-pip-check-reqs==2.5.1; python_version >= '3.9'
+pip-check-reqs==2.5.6; python_version >= '3.9'
 
 
 # Indirect dependencies for development that are not in dev-requirements.txt

--- a/minimum-constraints-install.txt
+++ b/minimum-constraints-install.txt
@@ -13,7 +13,7 @@
 # Need to comment out pip==26.0.1 due to issue https://github.com/pyupio/safety/issues/847
 # pip==25.0; python_version == '3.8'
 # pip==26.0.1; python_version == '3.9'
-pip==26.1; python_version >= '3.10'
+pip==26.1.2; python_version >= '3.10'
 setuptools==70.0.0; python_version == '3.8'
 setuptools==78.1.1; python_version >= '3.9'
 # Note on not specifying 'setuptools-scm[toml]': Extras cannot be in constraints files


### PR DESCRIPTION
Backports #949 into 2.3.