### PR TITLE
2.3: Added missing dependency for defusedxml (needed by nltk>=3.10)

### DIFF
--- a/minimum-constraints-develop.txt
+++ b/minimum-constraints-develop.txt
@@ -122,6 +122,8 @@ appdirs==1.4.3
 bleach==3.3.0
 chardet==3.0.4
 contextlib2==0.6.0
+# defusedxml is used by nltk>=3.10.0
+defusedxml==0.7.1; python_version >= '3.10'
 filelock==3.16.1; python_version <= '3.9'
 filelock==3.20.3; python_version >= '3.10'
 gitdb==4.0.8


### PR DESCRIPTION
Backports #937 into 2.3.